### PR TITLE
initial separation of the extraction from the presentation of data

### DIFF
--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -1,0 +1,35 @@
+from bs4 import BeautifulSoup
+from utils import first, firstnn, extract_nodes
+
+"""
+rawParser.py extracts and returns the nodes from the article xml using BeautifulSoup so that functionality at higher levels may use and combine them as neccessary.
+
+"""
+
+def title(soup):
+    return first(extract_nodes(soup, "article-title"))
+
+def doi(soup):
+    doi_tags = extract_nodes(soup, "article-id", attr = "pub-id-type", value = "doi")
+    # the first article-id tag whose parent is article-meta
+    return first(filter(lambda tag: tag.parent.name == "article-meta", doi_tags))
+
+def journal_id(soup):
+    # the first non-nil tag
+    return firstnn(extract_nodes(soup, "journal-id", attr = "journal-id-type", value = "hwp"))
+
+def journal_title(soup):
+    return first(extract_nodes(soup, "journal-title"))
+
+def journal_issn(soup, pub_format):
+    return first(extract_nodes(soup, "issn", attr = "publication-format", value = pub_format))
+
+def publisher(soup):
+    return first(extract_nodes(soup, "publisher-name"))
+
+def article_type(soup):
+    # returns raw data, just that the data doesn't contain any BS nodes
+    return first(extract_nodes(soup, "article")).get('article-type')
+
+def keyword_group(soup):
+    return extract_nodes(soup, "kwd-group")

--- a/elifetools/tests/unittests/raw_parser_test.py
+++ b/elifetools/tests/unittests/raw_parser_test.py
@@ -1,0 +1,41 @@
+import os, unittest
+from bs4 import BeautifulStoneSoup as bss
+
+import parseJATS as parser
+import rawJATS as raw_parser
+
+class JatsParser(unittest.TestCase):
+    def setUp(self):
+        self.kitchen_sink_xml = os.path.join(os.getcwd(), 'sample-xml/elife-kitchen-sink.xml')
+        self.xml = os.path.join(os.getcwd(), 'sample-xml/elife00013.xml')
+        self.soup = parser.parse_document(self.kitchen_sink_xml)
+
+    def tearDown(self):
+        self.soup = None
+
+    def test_quickly(self):
+        struct = [
+            (parser.doi, u"10.7554/eLife.00013"),
+            (parser.journal_id, u"eLife"),
+            (parser.journal_title, u"eLife"),
+            #(parser.journal_issn, u"2050-084X"),
+            (parser.publisher, u"eLife Sciences Publications, Ltd"),
+        ]
+        for func, expected in struct:
+            soup = parser.parse_document(self.kitchen_sink_xml)
+            got = func(soup)
+            try:
+
+                self.assertEqual(got, expected)
+            except AssertionError:
+                print 'failed on',func,'expected',expected,'got',got
+                raise
+        soup = parser.parse_document(self.kitchen_sink_xml)        
+        self.assertEqual(parser.journal_issn(soup, pub_format="electronic"), u"2050-084X")
+
+    def test_quickly2(self):
+        soup = parser.parse_document(self.xml)
+        self.assertEqual(raw_parser.article_type(soup), "research-article")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -1,0 +1,184 @@
+import cgi
+import htmlentitydefs
+
+def first(x):
+    "returns the first element of an iterable, swallowing index errors and returning None"
+    try:
+        return x[0]
+    except IndexError:
+        return None
+
+def firstnn(x):
+    "returns the first non-nil value within given iterable"
+    return first(filter(None, x))
+
+def swap_en_dashes(textHTMLEntities):
+    title = textHTMLEntities.replace("&#8211;", "&#x02013;")#.encode('ascii', 'xmlcharrefreplace')
+    return title
+
+def unicodeToHTMLEntities(text):
+    """Converts unicode to HTML entities.  For example '&' becomes '&amp;'."""
+    returnText = cgi.escape(text).encode('ascii', 'xmlcharrefreplace')
+    return returnText
+
+def format_text(title_text):
+    textHTMLEntities = unicodeToHTMLEntities(title_text)
+    textHTMLEntitiesReverted = swap_en_dashes(textHTMLEntities)
+    return textHTMLEntitiesReverted
+
+def nullify(function):
+    """
+    If list length is zero then return None,
+    otherwise return the list as given
+    """
+    def wrapper(*args, **kwargs):
+        value = function(*args, **kwargs)
+        if(type(value) == list and len(value) == 0):
+            return None
+        else:
+            return value
+        return value
+    return wrapper
+
+def flatten(function):
+    """
+    Convert or flatten value; if list length is zero then return None,
+    if length of a list is 1, convert to a string, otherwise return
+    the list as given
+    """
+    def wrapper(*args, **kwargs):
+        value = function(*args, **kwargs)
+        if(type(value) == list and len(value) == 0):
+            return None
+        elif(type(value) == list and len(value) == 1):
+            # If there is only one list element, return a singleton
+            return value[0]
+        else:
+            return value
+        return value
+    return wrapper
+
+def strip_strings(value):
+    """
+    Strip excess whitespace, on strings, and simple lists
+    using recursion
+    """
+    if (value == None):
+        return None
+    elif (type(value) == list):
+        # List, so recursively strip elements
+        for i in range(0, len(value)):
+            value[i] = strip_strings(value[i])
+        return value
+    else:
+        try:
+            value = value.replace("  ", " ")
+            return value.strip()
+        except(AttributeError):
+            return value
+
+def strip_punctuation_space(value):
+    """
+    Strip excess whitespace prior to punctuation
+    using recursion
+    """
+    if (value == None):
+        return None
+    elif (type(value) == list):
+        # List, so recursively strip elements
+        for i in range(0, len(value)):
+            value[i] = strip_punctuation_space(value[i])
+        return value
+    else:
+        try:
+            value = value.replace(" .", ".")
+            value = value.replace(" :", ":")
+            value = value.replace("( ", "(")
+            value = value.replace(" )", ")")
+            return value
+        except(AttributeError):
+            return value
+
+def strippen(function):
+    """
+    Strip excess whitespace as a decorator
+    """
+    def wrapper(*args, **kwargs):
+        value = function(*args, **kwargs)
+        return strip_strings(value)
+    return wrapper
+
+def inten(function):
+    """
+    Try to convert to int as a decorator
+    """
+    def wrapper(*args, **kwargs):
+        value = function(*args, **kwargs)
+        if (value == None):
+            return None
+        else:
+            try:
+                return int(value)
+            except(TypeError):
+                return value
+    return wrapper
+
+def revert_entities(function):
+    "this is the decorator"
+    def wrapper(*args, **kwargs):
+        text = function(*args, **kwargs)
+        formatted_text = format_text(text)
+        return formatted_text
+    return wrapper
+
+
+
+
+
+def extract_nodes(soup, nodename, attr = None, value = None):
+    tags = soup.find_all(nodename)
+    if attr != None and value != None:
+        # refine nodes further by their attributes
+        return filter(lambda tag: tag.get(attr) == value, tags)
+    return tags
+
+# deprecate?
+def extract_first_node(soup, nodename):
+    return first(extract_nodes(soup, nodename))
+
+#@strippen
+#@revert_entities
+def node_text(tag):
+    return getattr(tag, 'text', None)
+
+
+
+#
+# deprecated
+#
+
+# double handling and mixing responsibilities.
+# use `extract_nodes` and `node_text`
+def extract_node_text(soup, nodename, attr = None, value = None):
+    """
+    Extract node text by nodename, unless attr is supplied
+    If attr and value is specified, find all the nodes and search
+      by attr and value for the first node
+    """
+    tag_text = None
+    if(attr == None):
+        tag = extract_first_node(soup, nodename)
+        try:
+            tag_text = tag.text
+        except(AttributeError):
+            # Tag text not found
+            return None
+    else:
+        tags = extract_nodes(soup, nodename, attr, value)
+        for tag in tags:
+            try:
+                if tag[attr] == value:
+                    tag_text = tag.text
+            except KeyError:
+                continue
+    return tag_text


### PR DESCRIPTION
added a possible approach to separating the handling of raw, untransformed, data from article xml with rawJATS.py and shifting the presentation into parseJATS.py. only seven or eight functions have been done thus far as an example, but all of the lettuce tests pass as well as my own quick and very dirty unnittests