### PR TITLE
Related article parsing.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -383,7 +383,19 @@ def full_digest(soup):
     else:
         return None
 
+def related_article(soup):
+    related_articles = []
+    
+    related_article_tags = raw_parser.related_article(soup)
 
+    for tag in related_article_tags:
+        related_article = {}
+        related_article["ext_link_type"] = tag.get("ext-link-type")
+        related_article["related_article_type"] =tag.get("related-article-type")
+        related_article["xlink_href"] = tag.get("xlink:href")
+        related_articles.append(related_article)
+    
+    return related_articles
 
 #
 # HERE BE DRAGONS

--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -121,6 +121,9 @@ def subject_area(soup, subject_group_type = None):
 def display_channel(soup):
     return (subject_area(soup, subject_group_type = "display-channel"))
 
+def related_article(soup):
+    related_article_tags = extract_nodes(soup, "related-article")
+    return filter(lambda tag: tag.parent.name == "article-meta", related_article_tags)
 
 
 #
@@ -152,4 +155,3 @@ def publisher_loc(ref):
 
 def publisher_name(ref):
     return extract_node(ref, "publisher-name")
-

--- a/elifetools/tests/features/get_related_article.feature
+++ b/elifetools/tests/features/get_related_article.feature
@@ -1,0 +1,31 @@
+Feature: Get related articles from the document
+  In order to use the related articles of this article
+  as a script 
+  I will parse the related article from the xml file
+  
+  Scenario Outline: Count the number of related articles
+    Given I have the document <document>
+    When I count the number of related articles
+    Then I count the total as <count>
+  
+  Examples:
+    | document                    | count
+    | elife-kitchen-sink.xml      | 1    
+    | elife00013.xml              | 1      
+
+
+  Scenario Outline: Get related articles
+    Given I have the document <document>
+    When I get the related articles
+    And I get the list item <list_item>
+    Then I see the string <string>
+  
+  Examples:
+    | document                    | list_item                     | string
+    | elife-kitchen-sink.xml      | [0]['ext_link_type']          | doi
+    | elife-kitchen-sink.xml      | [0]['related_article_type']   | commentary
+    | elife-kitchen-sink.xml      | [0]['xlink_href']             | 10.7554/eLife.00013
+    | elife00013.xml              | [0]['ext_link_type']          | doi
+    | elife00013.xml              | [0]['related_article_type']   | commentary
+    | elife00013.xml              | [0]['xlink_href']             | 10.7554/eLife.00242
+

--- a/elifetools/tests/features/more_parse_steps.py
+++ b/elifetools/tests/features/more_parse_steps.py
@@ -84,3 +84,11 @@ def i_get_the_digest(step):
 @step(u'I get the full digest')
 def i_get_the_full_digest(step):
     world.string = pm.full_digest(world.filecontent)
+    
+@step(u'I count the number of related articles')
+def i_count_the_number_of_related_articles(step):
+    world.count = len(pm.related_article(world.filecontent))
+    
+@step(u'I get the related articles')
+def i_get_the_related_articles(step):
+    world.list = pm.related_article(world.filecontent)


### PR DESCRIPTION
The basics of parsing related-article. This is a piece in order to supprot elife-bot author emails functionality.