### PR TITLE
If a body content paragraph has no text then return a blank dict, …

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1740,6 +1740,10 @@ def body_block_content(tag):
 
         tag_content["text"] = node_contents_str(tag_copy)
 
+        # After all that, if the text is empty then return an empty dict
+        if not node_contents_str(tag_copy):
+            return OrderedDict()
+
     elif tag.name == "table-wrap":
         tag_content["type"] = "table"
         set_if_value(tag_content, "doi", object_id_doi(tag, tag.name))

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -162,6 +162,10 @@ class TestParseJats(unittest.TestCase):
          OrderedDict([('type', 'paragraph'), ('text', u'content')])
          ),
 
+        ('<root><p><fig id="fig7" position="float"><graphic xlink:href="elife-00498-fig7-v1.tif"/></fig></p></root>',
+         OrderedDict()
+         ),
+
         ('<root><fig id="fig1"><caption><title>Fig title not in a paragraph</title></caption><graphic xlink:href="elife-00639-fig1-v1.tif"/></fig></root>',
          OrderedDict([('type', 'image'), ('id', u'fig1'), ('title', u'Fig title not in a paragraph'), ('alt', '')])
          ),


### PR DESCRIPTION
…essentially removes it from the body rendering.