### PR TITLE
Body json content in media should be ignored, instead of from video (…

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1716,7 +1716,7 @@ def body_block_content_render(tag):
     tag_content_content = []
 
     # Collect the content of the tag but only for some tags
-    if tag.name not in ["p", "fig", "table-wrap", "list", "video"]:
+    if tag.name not in ["p", "fig", "table-wrap", "list", "media"]:
         for child_tag in tag:
             if not(hasattr(child_tag, 'name')):
                 continue


### PR DESCRIPTION
…which is not an XML tag name).