### PR TITLE
Body content image titles, a second fallback is to use the label as …

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1964,6 +1964,9 @@ def body_block_content(tag):
             sentences = first_paragraph_text.split(". ")
             if len(sentences) > 0:
                 tag_content["title"] = sentences[0]
+        # If there is still not title, then use the label
+        if "title" not in tag_content and "label" in tag_content:
+            tag_content["title"] = tag_content["label"]
         # Now can add the caption after all possible title values are added
         if len(caption_content) > 0:
             tag_content["caption"] = caption_content

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -305,7 +305,7 @@ class TestParseJats(unittest.TestCase):
          ),
 
         ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><fig id="fig8" position="float"><label>Reviewers’ figure 1</label><caption/><graphic xlink:href="elife-00723-resp-fig1-v1.tif"/></fig></root>',
-         OrderedDict([('type', 'image'), ('id', u'fig8'), ('label', u'Reviewers\u2019 figure 1'), ('alt', ''), ('uri', u'elife-00723-resp-fig1-v1.tif')])
+         OrderedDict([('type', 'image'), ('id', u'fig8'), ('label', u'Reviewers\u2019 figure 1'), ('title', u'Reviewers\u2019 figure 1'),('alt', ''), ('uri', u'elife-00723-resp-fig1-v1.tif')])
          ),
 
         ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><fig id="fig8" position="float"><label>Reviewers’ figure 1</label><caption><p>First sentence</p></caption><graphic xlink:href="elife-00723-resp-fig1-v1.tif"/></fig></root>',


### PR DESCRIPTION
…the title value, if the fig has no title and no caption.