### PR TITLE
Abstract JSON as HTML and complete

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -6,6 +6,7 @@ import time
 import calendar
 from slugify import slugify
 from utils import *
+from utils_html import xml_to_html
 import rawJATS as raw_parser
 import re
 from collections import OrderedDict
@@ -1854,7 +1855,10 @@ def body_block_paragraph_content(text):
         tag_content["text"] = unicode(text)
     return tag_content
 
-def body_block_content(tag):
+def body_block_content(tag, html_flag=True):
+
+    # Configure the XML to HTML conversion preference for shorthand use below
+    convert = lambda xml_string: xml_to_html(html_flag, xml_string)
 
     tag_content = OrderedDict()
 
@@ -1882,7 +1886,7 @@ def body_block_content(tag):
         tag_copy = remove_tag_from_tag(tag_copy, unwanted_tag_names)
 
         if node_contents_str(tag_copy):
-            tag_content["text"] = node_contents_str(tag_copy)
+            tag_content["text"] = convert(node_contents_str(tag_copy))
 
     elif tag.name == "disp-quote":
         tag_content["type"] = "quote"
@@ -2165,7 +2169,7 @@ def author_response(soup):
 def render_abstract_json(abstract_tag):
     abstract_json = OrderedDict()
     set_if_value(abstract_json, "doi", object_id_doi(abstract_tag))
-    for child_tag in body_blocks(abstract_tag):
+    for child_tag in remove_doi_paragraph(body_blocks(abstract_tag)):
         if body_block_content(child_tag) != {}:
             if "content" not in abstract_json:
                  abstract_json["content"] = []

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -547,6 +547,10 @@ class TestParseJats(unittest.TestCase):
         None
          ),
 
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"><abstract><object-id pub-id-type="doi">10.7554/eLife.00001.001</object-id><p>Example <sub>in</sub> <italic>cis</italic> <sc>or</sc> <italic>trans</italic> <underline>and</underline> <italic>Gfrα2</italic> <inline-formula><mml:math id="inf1"><mml:mstyle displaystyle="true" scriptlevel="0"><mml:mrow><mml:munder><mml:mo/><mml:mi>m</mml:mi></mml:munder><mml:mrow><mml:msub><mml:mover accent="true"><mml:mi>p</mml:mi><mml:mo/></mml:mover><mml:mi>m</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:mrow></mml:mstyle></mml:math></inline-formula> <sup>by</sup> <bold>its</bold> co-receptors as *p&lt;0.05 &gt;0.25% <xref ref-type="bibr" rid="bib25">Schneider et al., 2006</xref> and ligands.</p><p><bold>DOI:</bold><ext-link ext-link-type="doi" xlink:href="10.7554/eLife.00001.001">http://dx.doi.org/10.7554/eLife.00001.001</ext-link></p></abstract></root>',
+        OrderedDict([('doi', u'10.7554/eLife.00001.001'), ('content', [OrderedDict([('type', 'paragraph'), ('text', 'Example <sub>in</sub> <i>cis</i> <span class="small-caps">or</span> <i>trans</i> <span class="underline">and</span> <i>Gfr\xce\xb12</i> <math id="inf1"><mstyle displaystyle="true" scriptlevel="0"><mrow><munder><mo></mo><mi>m</mi></munder><mrow><msub><mover accent="true"><mi>p</mi><mo></mo></mover><mi>m</mi></msub><mo>=</mo><mn>0</mn></mrow></mrow></mstyle></math> <sup>by</sup> <b>its</b> co-receptors as *p&lt;0.05 &gt;0.25% <a href="#bib25">Schneider et al., 2006</a> and ligands.')])])])
+         ),
+
         )
     def test_abstract_json(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)

--- a/elifetools/tests/test_utils_html.py
+++ b/elifetools/tests/test_utils_html.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+
+import unittest
+import os
+import time
+from ddt import ddt, data, unpack
+
+os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import utils_html
+
+
+@ddt
+class TestUtilsHtml(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_tag = type('', (object,), {})
+        setattr(self.mock_tag, 'name', 'foo')
+
+    @unpack
+    @data(
+        (False, None, None),
+        (True, None, None),
+        (True, '<p><bold>A</bold> <italic>α</italic> <underline>c</underline></p>',
+         '<p><b>A</b> <i>α</i> <span class="underline">c</span></p>'),
+        (False, '<p><bold>A</bold> <italic>α</italic> <underline>c</underline></p>',
+         '<p><bold>A</bold> <italic>α</italic> <underline>c</underline></p>'),
+        (True, '<p><bold>A</bold> 1 &lt; 2 &gt; 1 <xref rid="bib1">&gt;α&lt;</xref>&gt;</p>',
+         '<p><b>A</b> 1 &lt; 2 &gt; 1 <a href="#bib1">&gt;\xce\xb1&lt;</a>&gt;</p>'),
+        )
+    def test_xml_to_html(self, html_flag, xml_string, expected):
+        self.assertEqual(utils_html.xml_to_html(html_flag, xml_string), expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/elifetools/utils_html.py
+++ b/elifetools/utils_html.py
@@ -1,0 +1,49 @@
+import re
+from bs4 import BeautifulSoup
+
+def xml_to_html(html_flag, xml_string):
+    "For formatting json output into HTML friendly format"
+    if not xml_string or not html_flag is True:
+        return xml_string
+    html_string = xml_string
+    html_string = replace_xref_tags(html_string)
+    html_string = replace_simple_tags(html_string, 'italic', 'i')
+    html_string = replace_simple_tags(html_string, 'bold', 'b')
+    html_string = replace_simple_tags(html_string, 'underline', 'span', '<span class="underline">')
+    html_string = replace_simple_tags(html_string, 'sc', 'span', '<span class="small-caps">')
+    html_string = replace_simple_tags(html_string, 'inline-formula', None)
+    html_string = replace_simple_tags(html_string)
+    # Run it through BeautifulSoup as HTML, this encodes unmatched angle brackets
+    soup = BeautifulSoup(html_string, 'html.parser')
+    html_string = soup.encode()
+    return html_string
+
+def replace_simple_tags(s, from_tag='italic', to_tag='i', to_open_tag=None):
+    """
+    Replace tags such as <italic> to <i>
+    This does not validate markup
+    """
+    if to_open_tag:
+        s = s.replace('<' + from_tag + '>', to_open_tag)
+    elif to_tag:
+        s = s.replace('<' + from_tag + '>', '<' + to_tag + '>')
+    else:
+        s = s.replace('<' + from_tag + '>', '')
+
+    if to_tag:
+        s = s.replace('</' + from_tag + '>', '</' + to_tag + '>')
+    else:
+        s = s.replace('</' + from_tag + '>', '')
+
+    return s
+
+def replace_xref_tags(s):
+    for tag_match in re.finditer("<(xref.*?)>", s):
+        rid_match = re.finditer('rid="(.*)"', tag_match.group())
+        if rid_match:
+            rid = rid_match.next().group(1)
+            new_tag = '<a href="#' + rid + '">'
+            p = re.compile('<' + tag_match.group(1) + '>')
+            s = p.sub(new_tag, s)
+    s = replace_simple_tags(s, 'xref', 'a')
+    return s


### PR DESCRIPTION
The abstract JSON value here excludes the "DOI paragraph" content. The basics of XML to HTML conversion is also applied to the abstract content. Is passing tests and not raising any generation exceptions.

The conversion of XML to HTML once merged will be continued and tweaked as required as the other JSON values are converted to HTML.