### PR TITLE
HTML format title and impact statement

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1689,6 +1689,9 @@ def label(tag, parent_tag_name=None):
         label = node_contents_str(label_tag)
     return label
 
+def full_title_json(soup):
+    return xml_to_html(True, full_title(soup))
+
 def impact_statement_json(soup):
     return xml_to_html(True, impact_statement(soup))
 

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1689,6 +1689,9 @@ def label(tag, parent_tag_name=None):
         label = node_contents_str(label_tag)
     return label
 
+def impact_statement_json(soup):
+    return xml_to_html(True, impact_statement(soup))
+
 def acknowledgements_json(soup):
     if raw_parser.acknowledgements(soup):
         return body_block_content_render(raw_parser.acknowledgements(soup))[0].get("content")

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -50,6 +50,14 @@ class TestParseJats(unittest.TestCase):
 
     @unpack
     @data(
+        ("elife04493.xml", "Neuron hemilineages provide the functional ground plan for the <i>Drosophila</i> ventral nervous system"))
+    def test_full_title_json(self, filename, expected):
+        full_title_json = parser.full_title_json(self.soup(filename))
+        self.assertEqual(expected, full_title_json)
+
+
+    @unpack
+    @data(
         ("elife04490.xml", "Both the frequency of sesquiterpene-emitting individuals and the defense capacity of individual plants determine the consequences of sesquiterpene volatile emission for individuals and their neighbors in populations of the wild tobacco <i>Nicotiana attenuata</i>."),
         ("elife_poa_e06828.xml", ""))
     def test_impact_statement_json(self, filename, expected):

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -50,6 +50,16 @@ class TestParseJats(unittest.TestCase):
 
     @unpack
     @data(
+        ("elife04490.xml", "Both the frequency of sesquiterpene-emitting individuals and the defense capacity of individual plants determine the consequences of sesquiterpene volatile emission for individuals and their neighbors in populations of the wild tobacco <i>Nicotiana attenuata</i>."),
+        ("elife_poa_e06828.xml", ""))
+    def test_impact_statement_json(self, filename, expected):
+        impact_statement_json = parser.impact_statement_json(self.soup(filename))
+        self.assertEqual(expected, impact_statement_json)
+
+
+
+    @unpack
+    @data(
         ("elife-kitchen-sink.xml", list),
         ("elife_poa_e06828.xml", None))
     def test_acknowledgements_json_by_file(self, filename, expected):

--- a/elifetools/tests/test_utils_html.py
+++ b/elifetools/tests/test_utils_html.py
@@ -35,6 +35,8 @@ class TestUtilsHtml(unittest.TestCase):
          'Link 2 <a href="https://doi.org/10.7554/eLife.00001.012">http://dx.doi.org/10.7554/eLife.00001.012</a>'),
         (True, 'Bad link 1 <ext-link xlink:href="10.7554/eLife.00001.012">http://dx.doi.org/10.7554/eLife.00001.012</ext-link>',
          'Bad link 1 <ext-link xlink:href="10.7554/eLife.00001.012">http://dx.doi.org/10.7554/eLife.00001.012</ext-link>'),
+        (True, '<p>The Panda database (<ext-link ext-link-type="uri" xlink:href="http://circadian.salk.edu/about.html)%20does%20not%20indicate%20restoration%20of%20Cyp2b10">http://circadian.salk.edu/about.html) does not indicate restoration of <italic>Cyp2b10</italic></ext-link> cycling by restricted feeding of clockless mice.</p>',
+         '<p>The Panda database (<a href="http://circadian.salk.edu/about.html)%20does%20not%20indicate%20restoration%20of%20Cyp2b10">http://circadian.salk.edu/about.html) does not indicate restoration of <i>Cyp2b10</i></a> cycling by restricted feeding of clockless mice.</p>'),
         )
     def test_xml_to_html(self, html_flag, xml_string, expected):
         self.assertEqual(utils_html.xml_to_html(html_flag, xml_string), expected)

--- a/elifetools/utils_html.py
+++ b/elifetools/utils_html.py
@@ -48,8 +48,8 @@ def replace_xref_tags(s):
             try:
                 rid = rid_match.next().group(1)
                 new_tag = '<a href="#' + rid + '">'
-                p = re.compile('<' + tag_match.group(1) + '>')
-                s = p.sub(new_tag, s)
+                old_tag = '<' + tag_match.group(1) + '>'
+                s = s.replace(old_tag, new_tag)
                 # Replace all close tags even if one open tag gets replaced
                 s = replace_simple_tags(s, 'xref', 'a')
             except StopIteration:
@@ -76,8 +76,8 @@ def replace_ext_link_tags(s):
                     new_tag = '<a href="' + xlink + '">'
                 elif ext_link_type.startswith('doi'):
                     new_tag = '<a href="https://doi.org/' + xlink + '">'
-                p = re.compile('<' + tag_match.group(1) + '>')
-                s = p.sub(new_tag, s)
+                old_tag = '<' + tag_match.group(1) + '>'
+                s = s.replace(old_tag, new_tag)
                 # Replace all close tags even if one open tag gets replaced
                 s = replace_simple_tags(s, 'ext-link', 'a')
             except StopIteration:


### PR DESCRIPTION
New functions to produce HTML format of the article title and impact statement.

Also includes a change to the HTML rewriting to overcome a regular expression error in one edge case article - using string replace instead should be less error prone here.