### PR TITLE
added support for extracting and parsing mixed-citation elements

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -513,6 +513,30 @@ def related_article(soup):
     
     return related_articles
 
+def mixed_citations(soup):
+    mc_tags = raw_parser.mixed_citations(soup)
+    def name(nom):
+        return {
+            'surname': nom.surname.text,
+            'given': nom.find('given-names').text,
+        }
+    def do(mc):
+        return {
+            'journal': {
+                'name': mc.source.text,
+                'volume': mc.volume.text,
+                'fpage':  mc.fpage.text,
+                'lpage': mc.lpage.text,
+            },
+            'article': {
+                'title': mc.find('article-title').text,
+                'doi': mc.find('pub-id', attrs={'pub-id-type': 'doi'}).text,
+                'pub-date': map(int, ymd(soup)[::-1]),
+                'authors': map(name, mc.find('person-group', attrs={'person-group-type': 'author'}).contents),
+            },
+        }
+    return map(do, mc_tags)
+
 def component_doi(soup):
     """
     Look for all object-id of pub-type-id = doi, these are the component DOI tags

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -526,7 +526,7 @@ def mixed_citations(soup):
                 'name': mc.source.text,
                 'volume': mc.volume.text,
                 'fpage':  mc.fpage.text,
-                'lpage': mc.lpage.text,
+                'lpage': node_text(mc.lpage),
             },
             'article': {
                 'title': mc.find('article-title').text,

--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -179,6 +179,9 @@ def related_article(soup):
     related_article_tags = extract_nodes(soup, "related-article")
     return filter(lambda tag: tag.parent.name == "article-meta", related_article_tags)
 
+def mixed_citations(soup):
+    return extract_nodes(soup, 'mixed-citation')
+
 def related_object(soup):
     return extract_nodes(soup, "related-object")
 
@@ -423,3 +426,4 @@ def award_group(soup):
 
 def principal_award_recipient(soup):
     return extract_nodes(soup, "principal-award-recipient")
+

--- a/elifetools/sample-xml/elife-kitchen-sink.xml
+++ b/elifetools/sample-xml/elife-kitchen-sink.xml
@@ -302,6 +302,11 @@
                     <month>07</month>
                     <year>2012</year>
                 </date>
+                <fn>
+                    <p>
+                        <mixed-citation publication-type="journal"><person-group person-group-type="author"><name><surname>Straussman</surname><given-names>R</given-names></name><name><surname>Morikawa</surname><given-names>T</given-names></name><name><surname>Shee</surname><given-names>K</given-names></name><name><surname>Barzily-Rokni</surname><given-names>M</given-names></name><name><surname>Qian</surname><given-names>ZR</given-names></name><name><surname>Du</surname><given-names>J</given-names></name><name><surname>Davis</surname><given-names>A</given-names></name><name><surname>Mongare</surname><given-names>MM</given-names></name><name><surname>Gould</surname><given-names>J</given-names></name><name><surname>Frederick</surname><given-names>DT</given-names></name><name><surname>Cooper</surname><given-names>ZA</given-names></name><name><surname>Chapman</surname><given-names>PB</given-names></name><name><surname>Solit</surname><given-names>DB</given-names></name><name><surname>Ribas</surname><given-names>A</given-names></name><name><surname>Lo</surname><given-names>RS</given-names></name><name><surname>Flaherty</surname><given-names>KT</given-names></name><name><surname>Ogino</surname><given-names>S</given-names></name><name><surname>Wargo</surname><given-names>JA</given-names></name><name><surname>Golub</surname><given-names>TR</given-names></name></person-group>. <day>26</day><month>07</month><year>2012</year>. <article-title>Tumour micro-environment elicits innate resistance to RAF inhibitors through HGF secretion</article-title>. <source>Nature</source><volume>487</volume>:<fpage>500</fpage>–<lpage>504</lpage>. doi: <pub-id pub-id-type="doi">10.1038/nature11183</pub-id>.</mixed-citation>
+                    </p>
+                </fn>
             </history>
             <permissions>
                 <copyright-statement>&#xa9; 2012, Alegado et al</copyright-statement>

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1732,12 +1732,10 @@ class TestParseJats(unittest.TestCase):
         self.assertEqual(self.json_expected(filename, "volume"),
                          parser.volume(self.soup(filename)))
 
-
-
-
-
-
-
+    def test_parse_mixed_citations(self):
+        data = parser.mixed_citations(self.soup('elife-kitchen-sink.xml'))
+        expected = [{'article': {'authors': [{'given': u'R', 'surname': u'Straussman'}, {'given': u'T', 'surname': u'Morikawa'}, {'given': u'K', 'surname': u'Shee'}, {'given': u'M', 'surname': u'Barzily-Rokni'}, {'given': u'ZR', 'surname': u'Qian'}, {'given': u'J', 'surname': u'Du'}, {'given': u'A', 'surname': u'Davis'}, {'given': u'MM', 'surname': u'Mongare'}, {'given': u'J', 'surname': u'Gould'}, {'given': u'DT', 'surname': u'Frederick'}, {'given': u'ZA', 'surname': u'Cooper'}, {'given': u'PB', 'surname': u'Chapman'}, {'given': u'DB', 'surname': u'Solit'}, {'given': u'A', 'surname': u'Ribas'}, {'given': u'RS', 'surname': u'Lo'}, {'given': u'KT', 'surname': u'Flaherty'}, {'given': u'S', 'surname': u'Ogino'}, {'given': u'JA', 'surname': u'Wargo'}, {'given': u'TR', 'surname': u'Golub'}], 'doi': u'10.1038/nature11183', 'pub-date': [2014, 2, 28], 'title': u'Tumour micro-environment elicits innate resistance to RAF inhibitors through HGF secretion'}, 'journal': {'volume': u'487', 'lpage': u'504', 'name': u'Nature', 'fpage': u'500'}}]
+        self.assertEqual(expected, data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/elifetools/tests/test_raw_parser.py
+++ b/elifetools/tests/test_raw_parser.py
@@ -134,7 +134,7 @@ class TestJatsParser(unittest.TestCase):
 
     @unpack
     @data(
-        ("elife-kitchen-sink.xml", 176),
+        ("elife-kitchen-sink.xml", 177),
         ("elife_poa_e06828.xml", 3),
         ("elife07586.xml", 5)
     )
@@ -252,8 +252,8 @@ class TestJatsParser(unittest.TestCase):
 
     @unpack
     @data(
-        ("elife-kitchen-sink.xml", "doi", 77),
-        ("elife-kitchen-sink.xml", None, 78)
+        ("elife-kitchen-sink.xml", "doi", 78),
+        ("elife-kitchen-sink.xml", None, 79)
     )
     def test_pub_id_doi(self, filename, pub_id_type, expected_len):
         soup = parser.parse_document(sample_xml(filename))
@@ -324,7 +324,9 @@ class TestJatsParser(unittest.TestCase):
         soup = parser.parse_document(sample_xml(filename))
         self.assertEqual(len(raw_parser.principal_award_recipient(soup)), expected_len)
 
-
+    def test_mixed_citations(self):
+        self.soup = parser.parse_document(sample_xml('elife-kitchen-sink.xml'))
+        self.assertEqual(1, len(raw_parser.mixed_citations(self.soup)))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
very basic extraction, minor transformations. 

the bot-lax-adaptor can take this and turn it into something valid for the spec.

the spec has references to 'places' with geocoords and such and I couldn't find evidence of this in the xml. I'm guessing it's something planned.