### PR TITLE
Feature to parse the XML doctype and add it back to XML output

### DIFF
--- a/elifetools/sample-xml/simple-jats-doctype-1.1.xml
+++ b/elifetools/sample-xml/simple-jats-doctype-1.1.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1 20151215//EN"  "JATS-archivearticle1.dtd"><article article-type="research-article" dtd-version="1.1"><front/></article>

--- a/elifetools/sample-xml/simple-jats-doctype-1.1d3.xml
+++ b/elifetools/sample-xml/simple-jats-doctype-1.1d3.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1d3 20150301//EN"  "JATS-archivearticle1.dtd"><article article-type="research-article" dtd-version="1.1"><front/></article>

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -5,9 +5,7 @@ from ddt import ddt, data, unpack
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-os.sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-import xmlio
+from elifetools import xmlio
 
 from file_utils import sample_xml
 
@@ -22,6 +20,21 @@ class TestXmlio(unittest.TestCase):
     def test_parse(self, filename):
         root = xmlio.parse(sample_xml(filename))
         self.assertEqual(type(root), Element)
+
+    @data("elife-02833-v2.xml", "simple-jats-doctype-1.1.xml", "simple-jats-doctype-1.1d3.xml")
+    def test_input_output(self, filename):
+        """test parsing a file while retaining the doctype"""
+        with open(sample_xml(filename), "rb") as xml_file:
+            xml_output_expected = xml_file.read()
+        root, doctype_dict = xmlio.parse(sample_xml(filename), return_doctype_dict=True)
+        self.assertEqual(xmlio.output(root, None, doctype_dict), xml_output_expected)
+
+    @data("elife-02833-v2.xml")
+    def test_input_output_forcing_jats_doctype(self, filename):
+        with open(sample_xml(filename), "rb") as xml_file:
+            xml_output_expected = xml_file.read()
+        root, doctype_dict = xmlio.parse(sample_xml(filename), return_doctype_dict=True)
+        self.assertEqual(xmlio.output(root, 'JATS'), xml_output_expected)
 
     @unpack
     @data(("xmlio_input.xml", "inline-graphic", 2),


### PR DESCRIPTION
https://elifesciences.atlassian.net/browse/ELPP-2379   The new XML kitchen sink has a doctype denoting JATS v1.1.  Before, xmlio was always adding a doctype for JATS v1.1d3.

Added here: to parse() you can optionally return the doctype from ElementTree.XMLParser using a custom parser. 

In output(), you can supply a dict of values to be used in the doctype when the XML file is generated.

It should be backwards compatible while making it possible to use this new ability. Most specifically, I did not like how in elife-bot when we rewrite the xlink:href values when applying the version number, it would alter the doctype of the XML from what was read in to something different.