### PR TITLE
removed the logging stub from parseJATS.py

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -12,16 +12,6 @@ import rawJATS as raw_parser
 import re
 from collections import OrderedDict
 
-
-import logging
-logger = logging.getLogger('myapp')
-hdlr = logging.FileHandler(os.getcwd() + os.sep + 'test.log')
-formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-hdlr.setFormatter(formatter)
-logger.addHandler(hdlr) 
-logger.setLevel(logging.INFO)
-
-
 def parse_xml(xml):
     return BeautifulSoup(xml, ["lxml", "xml"])
 


### PR DESCRIPTION
it's not being used by anything, looks like copy+pasted code. 

it's also causing an issue with the new bot-lax-adaptor api that runs as the www-data user who doesn't have permission to write to test.log. 

libraries should probably use stream handlers and not file handlers.