### PR TITLE
Feature pub dates

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -278,9 +278,9 @@ def pub_date(soup):
     pub_date_date, pub_date_day, pub_date_month, pub_date_year, pub_date_timestamp
     Default date_type is pub
     """
-    pub_date = raw_parser.pub_date(soup, date_type = "pub")
+    pub_date = first(raw_parser.pub_date(soup, date_type="pub"))
     if pub_date is None:
-        pub_date = raw_parser.pub_date(soup, date_type = "publication")
+        pub_date = first(raw_parser.pub_date(soup, date_type="publication"))
     if pub_date is None:
         return None
     (day, month, year) = ymd(pub_date)
@@ -394,10 +394,10 @@ def collection_year(soup):
     """
     Pub date of type collection will hold a year element for VOR articles
     """
-    pub_date = raw_parser.pub_date_collection(soup, pub_type = "collection")
+    pub_date = first(raw_parser.pub_date(soup, pub_type="collection"))
     if pub_date is None:
         return None
-    
+
     year = None
     year_tag = raw_parser.year(pub_date)
     if year_tag:

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -286,6 +286,27 @@ def pub_date(soup):
     (day, month, year) = ymd(pub_date)
     return date_struct(year, month, day)
 
+def pub_dates(soup):
+    """
+    return a list of all the pub dates
+    """
+    pub_dates = []
+    tags = raw_parser.pub_date(soup)
+    for tag in tags:
+        pub_date = OrderedDict()
+        copy_attribute(tag.attrs, 'publication-format', pub_date)
+        copy_attribute(tag.attrs, 'date-type', pub_date)
+        copy_attribute(tag.attrs, 'pub-type', pub_date)
+        for tag_attr in ["date-type", "pub-type"]:
+            if tag_attr in tag.attrs:
+                (day, month, year) = ymd(tag)
+                pub_date['day'] = day
+                pub_date['month'] = month
+                pub_date['year'] = year
+                pub_date['date'] = date_struct_nn(year, month, day)
+        pub_dates.append(pub_date)
+    return pub_dates
+
 def history_date(soup, date_type = None):
     """
     Find a date in the history tag for the specific date_type

--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -57,11 +57,13 @@ def article_type(soup):
     # returns raw data, just that the data doesn't contain any BS nodes
     return first(extract_nodes(soup, "article")).get('article-type')
 
-def pub_date(soup, date_type):
-    return first(extract_nodes(soup, "pub-date", attr = "date-type", value = date_type))
-
-def pub_date_collection(soup, pub_type):
-    return first(extract_nodes(soup, "pub-date", attr = "pub-type", value = pub_type))
+def pub_date(soup, date_type=None, pub_type=None):
+    if date_type is not None:
+        return extract_nodes(soup, "pub-date", attr="date-type", value=date_type)
+    elif pub_type is not None:
+        return extract_nodes(soup, "pub-date", attr="pub-type", value=pub_type)
+    else:
+        return extract_nodes(soup, "pub-date")
 
 def history_date(soup, date_type):
     date_tags = extract_nodes(soup, "date", attr = "date-type", value = date_type)

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -2353,6 +2353,84 @@ class TestParseJats(unittest.TestCase):
         self.assertEqual(self.json_expected(filename, "media"),
                          parser.media(self.soup(filename)))
 
+    @unpack
+    @data(
+        # pub-date values from 00666 kitchen sink
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><article><pub-date publication-format="electronic" date-type="update"><day>11</day><month>08</month><year>2016</year></pub-date><pub-date publication-format="electronic" date-type="publication"><day>25</day><month>04</month><year>2016</year></pub-date><pub-date pub-type="collection"><year>2016</year></pub-date></article></root>',
+        [
+            OrderedDict([
+                ('publication-format', u'electronic'),
+                ('date-type', u'update'),
+                ('day', u'11'),
+                ('month', u'08'),
+                ('year', u'2016'),
+                (u'date', date_struct(2016, 8, 11))
+            ]),
+            OrderedDict([
+                ('publication-format', u'electronic'),
+                ('date-type', u'publication'),
+                ('day', u'25'),
+                ('month', u'04'),
+                ('year', u'2016'),
+                (u'date', date_struct(2016, 4, 25))
+            ]),
+            OrderedDict([
+                ('pub-type', u'collection'),
+                ('day', None),
+                ('month', None),
+                ('year', u'2016'),
+                (u'date', date_struct(2016, 1, 1))
+            ]),
+        ]
+        ),
+
+        # example from cstp77
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><article><pub-date publication-format="electronic" date-type="pub" iso-8601-date="2017-07-04"><day>04</day><month>07</month><year>2017</year></pub-date></article></root>',
+        [
+            OrderedDict([
+                ('publication-format', u'electronic'),
+                ('date-type', u'pub'),
+                ('day', u'04'),
+                ('month', u'07'),
+                ('year', u'2017'),
+                (u'date', date_struct(2017, 7, 4))
+            ])
+        ]
+        ),
+
+        # example from bmjopen-2013-003269
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><article><pub-date pub-type="ppub"><month>1</month><year>2014</year></pub-date><pub-date pub-type="epub-original"><day>30</day><month>1</month><year>2014</year></pub-date><pub-date pub-type="epub"><day>31</day><month>1</month><year>2014</year></pub-date></article></root>',
+        [
+            OrderedDict([
+                ('pub-type', u'ppub'),
+                ('day', None),
+                ('month', u'1'),
+                ('year', u'2014'),
+                (u'date', date_struct(2014, 1, 1))
+            ]),
+            OrderedDict([
+                ('pub-type', u'epub-original'),
+                ('day', u'30'),
+                ('month', u'1'),
+                ('year', u'2014'),
+                (u'date', date_struct(2014, 1, 30))
+            ]),
+            OrderedDict([
+                ('pub-type', u'epub'),
+                ('day',  u'31'),
+                ('month', u'1'),
+                ('year', u'2014'),
+                (u'date', date_struct(2014, 1, 31))
+            ]),
+        ]
+        ),
+    )
+    def test_pub_dates_edge_cases(self, xml_content, expected):
+        soup = parser.parse_xml(xml_content)
+        tag_content = parser.pub_dates(soup)
+        self.assertEqual(expected, tag_content)
+
+
     @data("elife-kitchen-sink.xml", "elife_poa_e06828.xml")
     def test_pub_date_timestamp(self, filename):
         self.assertEqual(self.json_expected(filename, "pub_date_timestamp"),

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1972,7 +1972,7 @@ class TestParseJats(unittest.TestCase):
     @data(("elife-kitchen-sink.xml", "pub", ('28', '02', '2014')))
     def test_ymd(self, filename, test_date_type, expected):
         soup = self.soup(filename)
-        date_tag = raw_parser.pub_date(soup, date_type=test_date_type)
+        date_tag = raw_parser.pub_date(soup, date_type=test_date_type)[0]
         self.assertEqual(expected, parser.ymd(date_tag))
 
     @unpack

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -116,6 +116,17 @@ def date_struct(year, month, day, tz = "UTC"):
         #logger.debug("date failed to convert: %s" % str(ymdtz))
         pass
 
+def date_struct_nn(year, month, day, tz="UTC"):
+    """
+    Assemble a date object but if day or month is none set them to 1
+    to make it easier to deal with partial dates
+    """
+    if not day:
+        day = 1
+    if not month:
+        month = 1
+    return date_struct(year, month, day, tz)
+
 def date_text(date_struct):
     # looks like: January 01, 2015
     return time.strftime("%B %d, %Y", date_struct) if date_struct else None


### PR DESCRIPTION
Refactor how the pub_date is extracted to be more flexible. A new parsing method to return a set of all pub dates in the article, with some tests on eLife and non-eLife values. 

For partial dates - missing a day, or missing a month and day - replace None values with the first of the day or month so it can create a structured date from it. The day and month values of None will still be readable using ``pub_dates()`` to determine how the date_struct was generated.