### PR TITLE
Feature xmlio append minidom

### DIFF
--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -3,8 +3,8 @@ import os
 import StringIO
 from ddt import ddt, data, unpack
 from xml.etree import ElementTree
-from xml.etree.ElementTree import Element
-
+from xml.etree.ElementTree import Element, SubElement
+from xml.dom import minidom
 from elifetools import xmlio
 
 from file_utils import sample_xml
@@ -88,6 +88,24 @@ class TestXmlio(unittest.TestCase):
         xml_output = xmlio.output_root(root, doctype, encoding)
         self.assertEqual(xml_output, xml_expected)
 
+    def test_append_minidom_xml_to_elementtree_xml(self):
+        "test coverage of an edge case"
+        parent = Element('root')
+        tag = SubElement(parent, 'i')
+        tag.text = "Text"
+        tag.tail = " and tail."
+        attributes = ["class"]
+        # Add a first example
+        xml = '<span><i>and</i> some <i>XML</i>.</span>'
+        reparsed = minidom.parseString(xml.encode('utf-8'))
+        parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed)
+        # Add another example to test more lines of code
+        xml = '<span class="span"> <i>more</i> text</span>'
+        reparsed = minidom.parseString(xml.encode('utf-8'))
+        parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed, False, attributes)
+        # Generate output and compare it
+        rough_string = ElementTree.tostring(parent)
+        self.assertEqual(rough_string, '<root><i>Text</i> and tail.<span><i>and</i> some <i>XML</i>.</span><span class="span"> <i>more</i> text</span></root>')
 
 if __name__ == '__main__':
     unittest.main()

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -157,6 +157,55 @@ class ElifeDocumentType(minidom.DocumentType):
             writer.write("]")
         writer.write(">"+newl)
 
+
+def append_minidom_xml_to_elementtree_xml(parent, xml, recursive=False, attributes=None):
+    """
+    Recursively,
+    Given an ElementTree.Element as parent, and a minidom instance as xml,
+    append the tags and content from xml to parent
+    Used primarily for adding a snippet of XML with <italic> tags
+    attributes: a list of attribute names to copy
+    """
+
+    # Get the root tag name
+    if recursive is False:
+        tag_name = xml.documentElement.tagName
+        node = xml.getElementsByTagName(tag_name)[0]
+        new_elem = SubElement(parent, tag_name)
+        if attributes:
+            for attribute in attributes:
+                if xml.documentElement.getAttribute(attribute):
+                    new_elem.set(attribute, xml.documentElement.getAttribute(attribute))
+    else:
+        node = xml
+        tag_name = node.tagName
+        new_elem = parent
+
+    i = 0
+    for child_node in node.childNodes:
+        if child_node.nodeName == '#text':
+            if not new_elem.text and i <= 0:
+                new_elem.text = child_node.nodeValue
+            elif not new_elem.text and i > 0:
+                new_elem_sub.tail = child_node.nodeValue
+            else:
+                new_elem_sub.tail = child_node.nodeValue
+
+        elif child_node.childNodes is not None:
+            new_elem_sub = SubElement(new_elem, child_node.tagName)
+            new_elem_sub = append_minidom_xml_to_elementtree_xml(new_elem_sub, child_node,
+                                                                 True, attributes)
+
+        i = i + 1
+
+    # Debug
+    #encoding = 'utf-8'
+    #rough_string = ElementTree.tostring(parent, encoding)
+    #print rough_string
+
+    return parent
+
+
 if __name__ == '__main__':
     
     # Sample usage


### PR DESCRIPTION
Originally from the older PoA generation code, this was moved to new Crossref generation code. Now, in refactoring Pubmed code, it makes more sense to move this function to a place where all libraries can use it and so there are no duplicates of this function. It makes sense, to me, to put this along side the other XML rewriting functions in elifetools ``xmlio.py``.