### PR TITLE
Parse article version history

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -133,6 +133,26 @@ def impact_statement(soup):
         return node_contents_str(first(extract_nodes(tag, "meta-value")))
     return ""
 
+def version_history(soup, html_flag=True):
+    "extract the article version history details"
+    convert = lambda xml_string: xml_to_html(html_flag, xml_string)
+    version_history = []
+    related_object_tags = raw_parser.related_object(raw_parser.article_meta(soup))
+    for tag in related_object_tags:
+        article_version = OrderedDict()
+        date_tag = first(raw_parser.date(tag))
+        if date_tag:
+            copy_attribute(date_tag.attrs, 'date-type', article_version, 'version')
+            (day, month, year) = ymd(date_tag)
+            article_version['day'] = day
+            article_version['month'] = month
+            article_version['year'] = year
+            article_version['date'] = date_struct_nn(year, month, day)
+        copy_attribute(tag.attrs, 'xlink:href', article_version)
+        set_if_value(article_version, "comment",
+                     convert(node_contents_str(first(raw_parser.comment(tag)))))
+        version_history.append(article_version)
+    return version_history
 
 def format_related_object(related_object):
     return related_object["id"], {}

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -148,7 +148,7 @@ def version_history(soup, html_flag=True):
             article_version['month'] = month
             article_version['year'] = year
             article_version['date'] = date_struct_nn(year, month, day)
-        copy_attribute(tag.attrs, 'xlink:href', article_version)
+        copy_attribute(tag.attrs, 'xlink:href', article_version, 'xlink_href')
         set_if_value(article_version, "comment",
                      convert(node_contents_str(first(raw_parser.comment(tag)))))
         version_history.append(article_version)

--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -65,8 +65,14 @@ def pub_date(soup, date_type=None, pub_type=None):
     else:
         return extract_nodes(soup, "pub-date")
 
+def date(soup, date_type=None):
+    if date_type is not None:
+        return extract_nodes(soup, "date", attr="date-type", value=date_type)
+    else:
+        return extract_nodes(soup, "date")
+
 def history_date(soup, date_type):
-    date_tags = extract_nodes(soup, "date", attr = "date-type", value = date_type)
+    date_tags = date(soup, date_type)
     return first(filter(lambda tag: tag.parent.name == "history", date_tags))
 
 def day(soup):

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -3400,5 +3400,79 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
         expected = [{'article': {'authorLine': u'R Straussman et al.', 'authors': [{'given': u'R', 'surname': u'Straussman'}, {'given': u'T', 'surname': u'Morikawa'}, {'given': u'K', 'surname': u'Shee'}, {'given': u'M', 'surname': u'Barzily-Rokni'}, {'given': u'ZR', 'surname': u'Qian'}, {'given': u'J', 'surname': u'Du'}, {'given': u'A', 'surname': u'Davis'}, {'given': u'MM', 'surname': u'Mongare'}, {'given': u'J', 'surname': u'Gould'}, {'given': u'DT', 'surname': u'Frederick'}, {'given': u'ZA', 'surname': u'Cooper'}, {'given': u'PB', 'surname': u'Chapman'}, {'given': u'DB', 'surname': u'Solit'}, {'given': u'A', 'surname': u'Ribas'}, {'given': u'RS', 'surname': u'Lo'}, {'given': u'KT', 'surname': u'Flaherty'}, {'given': u'S', 'surname': u'Ogino'}, {'given': u'JA', 'surname': u'Wargo'}, {'given': u'TR', 'surname': u'Golub'}], 'doi': u'10.1038/nature11183', 'pub-date': [2014, 2, 28], 'title': u'Tumour micro-environment elicits innate resistance to RAF inhibitors through HGF secretion'}, 'journal': {'volume': u'487', 'lpage': u'504', 'name': u'Nature', 'fpage': u'500'}}]
         self.assertEqual(expected, data)
 
+
+    @unpack
+    @data(
+        # example with no history
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><front><article-meta></article-meta></front></root>',
+         []
+        ),
+        # example based on 00666 kitchen sink
+        ('''<root xmlns:xlink="http://www.w3.org/1999/xlink"><front><article-meta><related-object ext-link-type="url" xlink:href="https://elifesciences.org/articles/e00666v1">
+<date date-type="v1" iso-8601-date="2016-04-25">
+<day>25</day>
+<month>04</month>
+<year>2016</year>
+</date>
+</related-object>
+<related-object ext-link-type="url" xlink:href="https://elifesciences.org/articles/e00666v2">
+<date date-type="v2" iso-8601-date="2016-06-12">
+<day>12</day>
+<month>06</month>
+<year>2016</year>
+</date>
+<comment>
+The first version of this article was enhanced considerably between versions of the XML instance. These changes can bee seen on
+<ext-link ext-link-type="uri" xlink:href="https://github.com/elifesciences/XML-mapping/blob/master/eLife00666.xml">Github</ext-link>
+.
+</comment>
+<!--
+If subsequent versions (v3 and onwards are published these will look like the below
+-->
+</related-object>
+<related-object ext-link-type="url" xlink:href="https://elifesciences.org/articles/e00666v3">
+<date date-type="v3" iso-8601-date="2016-06-27">
+<day>27</day>
+<month>06</month>
+<year>2016</year>
+</date>
+<comment>
+The author Christoph Wuelfing requested has surname was converted to the German spelling of "Wülfing".
+</comment>
+</related-object></article-meta></front></root>''',
+        [
+            OrderedDict([
+                ('version', u'v1'),
+                ('day', u'25'),
+                ('month', u'04'),
+                ('year', u'2016'),
+                ('date', date_struct(2016, 4, 25)),
+                ('xlink:href', u'https://elifesciences.org/articles/e00666v1')
+            ]), OrderedDict([
+                ('version', u'v2'),
+                ('day', u'12'),
+                ('month', u'06'),
+                ('year', u'2016'),
+                ('date', date_struct(2016, 6, 12)),
+                ('xlink:href', u'https://elifesciences.org/articles/e00666v2'),
+                ('comment', u'\nThe first version of this article was enhanced considerably between versions of the XML instance. These changes can bee seen on\n<a href="https://github.com/elifesciences/XML-mapping/blob/master/eLife00666.xml">Github</a>\n.\n')
+            ]), OrderedDict([
+                ('version', u'v3'),
+                ('day', u'27'),
+                ('month', u'06'),
+                ('year', u'2016'),
+                ('date', date_struct(2016, 6, 27)),
+                ('xlink:href', u'https://elifesciences.org/articles/e00666v3'),
+                ('comment', u'\nThe author Christoph Wuelfing requested has surname was converted to the German spelling of "W\xfclfing".\n')
+            ])
+        ]
+        ),
+    )
+    def test_version_history(self, xml_content, expected):
+        soup = parser.parse_xml(xml_content)
+        tag_content = parser.version_history(soup)
+        self.assertEqual(expected, tag_content)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -3447,14 +3447,14 @@ The author Christoph Wuelfing requested has surname was converted to the German 
                 ('month', u'04'),
                 ('year', u'2016'),
                 ('date', date_struct(2016, 4, 25)),
-                ('xlink:href', u'https://elifesciences.org/articles/e00666v1')
+                ('xlink_href', u'https://elifesciences.org/articles/e00666v1')
             ]), OrderedDict([
                 ('version', u'v2'),
                 ('day', u'12'),
                 ('month', u'06'),
                 ('year', u'2016'),
                 ('date', date_struct(2016, 6, 12)),
-                ('xlink:href', u'https://elifesciences.org/articles/e00666v2'),
+                ('xlink_href', u'https://elifesciences.org/articles/e00666v2'),
                 ('comment', u'\nThe first version of this article was enhanced considerably between versions of the XML instance. These changes can bee seen on\n<a href="https://github.com/elifesciences/XML-mapping/blob/master/eLife00666.xml">Github</a>\n.\n')
             ]), OrderedDict([
                 ('version', u'v3'),
@@ -3462,7 +3462,7 @@ The author Christoph Wuelfing requested has surname was converted to the German 
                 ('month', u'06'),
                 ('year', u'2016'),
                 ('date', date_struct(2016, 6, 27)),
-                ('xlink:href', u'https://elifesciences.org/articles/e00666v3'),
+                ('xlink_href', u'https://elifesciences.org/articles/e00666v3'),
                 ('comment', u'\nThe author Christoph Wuelfing requested has surname was converted to the German spelling of "W\xfclfing".\n')
             ])
         ]


### PR DESCRIPTION
Parse version history using the latest 00666 kitchen sink format in the test case.

This is a blocker of sorts as part of the version history API and workflows, the ability to parse the values from the XML file.

The format of the XML itself is not entirely confirmed; we decided to move forward with the format that is in the kitchen sink now, awaiting any changes. If the XML changes then I think we should be able to generate the same output (version, date, xlink_href, comment) from the final XML format that is decided.