### PR TITLE
More flexible abstract parsing

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -457,11 +457,11 @@ def abstracts(soup):
             abstract["title"] = node_text(title_tag)
         
         abstract["content"] = None
-        if len(paragraphs(tag)) > 0:
+        if raw_parser.paragraph(tag):
             abstract["content"] = ""
             abstract["full_content"] = ""
             
-            good_paragraphs = remove_doi_paragraph(paragraphs(tag))
+            good_paragraphs = remove_doi_paragraph(raw_parser.paragraph(tag))
             
             # Plain text content
             glue = ""

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -2505,6 +2505,56 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
         self.assertEqual(self.json_expected(filename, "abstracts"),
                          parser.abstracts(self.soup(filename)))
 
+    @unpack
+    @data(
+        # example based on eLife format
+        ('''<root xmlns:xlink="http://www.w3.org/1999/xlink"><front><article-meta>
+         <abstract>
+            <object-id pub-id-type="doi">10.7554/eLife.00666.001</object-id>
+            <p>This is the abstract.</p><p>eLife does not structure abstracts into sub headings except ...</p>
+         </abstract>
+         <abstract abstract-type="executive-summary">
+            <object-id pub-id-type="doi">10.7554/eLife.00666.002</object-id>
+            <title>eLife digest</title>
+            <p>eLife digest are now optional</p>
+        </abstract>
+        </article-meta></front></root>''',
+        'This is the abstract. eLife does not structure abstracts into sub headings except ...'
+        ),
+        # example based on BMJ Open bmjopen-4-e003269.xml
+        (u'''<root xmlns:xlink="http://www.w3.org/1999/xlink"><front><article-meta>
+<abstract><sec>
+<title>Objectives</title>
+<p>To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5 years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed.</p>
+</sec><sec>
+<title>Design</title>
+<p>A cross-sectional hospital-based surveillance study.</p>
+</sec><sec>
+<title>Setting</title>
+<p>5 reference paediatric hospitals across Abidjan.</p>
+</sec><sec>
+<title>Participants</title>
+<p>Children aged less than 5 years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study.</p>
+</sec><sec>
+<title>Primary and secondary outcome measures</title>
+<p>The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR.</p>
+</sec><sec>
+<title>Results</title>
+<p>Of 357 enrolled children (mean age 13.6±11.14 months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6–11 months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains.</p>
+</sec><sec>
+<title>Conclusions</title>
+<p>RVGE causes substantial morbidity among children under 5 years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.</p>
+</sec>
+</abstract>
+        </article-meta></front></root>''',
+        u'To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5\u2005years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed. A cross-sectional hospital-based surveillance study. 5 reference paediatric hospitals across Abidjan. Children aged less than 5\u2005years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study. The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR. Of 357 enrolled children (mean age 13.6\xb111.14\u2005months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6\u201311\u2005months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains. RVGE causes substantial morbidity among children under 5\u2005years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.'
+        ),
+    )
+    def test_abstract_edge_cases(self, xml_content, expected):
+        soup = parser.parse_xml(xml_content)
+        tag_content = parser.abstract(soup)
+        self.assertEqual(expected, tag_content)
+
     @data("elife-kitchen-sink.xml")
     def test_accepted_date_date(self, filename):
         self.assertEqual(self.json_expected(filename, "accepted_date_date"),


### PR DESCRIPTION
Small change to parsing abstract, seems to support existing test cases. 

There's an example abstract I want to have at least some content extracted, and this small change to the parser should not cause any changes to existing eLife format abstracts.

In future, the edge case example could be part of a new function to parse the abstract in parts in order to populate object values. This is becoming an issue in developing general purpose PubMed deposit generation code for non-eLife XML.