### PR TITLE
Changes to get xmlio tests to pass in Python 3.

### DIFF
--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -15,6 +15,7 @@ from xml.dom import minidom
 
 from elifetools import xmlio
 from elifetools.file_utils import sample_xml
+from elifetools.utils import unicode_value
 
 
 @ddt
@@ -75,7 +76,7 @@ class TestXmlio(unittest.TestCase):
     def test_output(self, xml, type, xml_expected):
         root = xmlio.parse(StringIO(xml))
         xml_output = xmlio.output(root, type)
-        self.assertEqual(xml_output, xml_expected)
+        self.assertEqual(xml_output.decode('utf-8'), xml_expected)
 
     @unpack
     @data(("<article/>", "", "", None,
@@ -92,7 +93,7 @@ class TestXmlio(unittest.TestCase):
         root = xmlio.parse(StringIO(xml))
         doctype = xmlio.build_doctype(qualifiedName, publicId, systemId, internalSubset)
         xml_output = xmlio.output_root(root, doctype, encoding)
-        self.assertEqual(xml_output, xml_expected)
+        self.assertEqual(xml_output.decode('utf-8'), xml_expected)
 
     def test_append_minidom_xml_to_elementtree_xml(self):
         "test coverage of an edge case"


### PR DESCRIPTION
Cleaned up result of trying to get the ``xmlio.py`` tests to pass. It looks like ElementTree in Python version 3.2 deprecated where the ``doctype`` support goes, so this will instead create a custom ``TreeBuilder`` object to overload the values.

If it wasn't clear from the code, this allows it to parse an XML file and retain the DOCTYPE and associated values, return them, and they can be used when writing file output to add the same DOCTYPE values.