### PR TITLE
Do not fail if an aff tag cannot be found for a contrib.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1251,6 +1251,8 @@ def format_authors(soup, contrib_tags, detail = "full", contrib_type=None):
 
 
 def format_aff(aff_tag):
+    if not aff_tag:
+        return None, {}
     values = {
         'dept': node_contents_str(first(extract_nodes(aff_tag, "institution", "content-type", "dept"))),
         'institution': node_contents_str(first(list(filter(lambda n: "content-type" not in n.attrs, extract_nodes(aff_tag, "institution"))))),

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1223,6 +1223,55 @@ class TestParseJats(unittest.TestCase):
         self.assertEqual(parser.format_author_line(author_names), expected)
 
 
+    @data(
+        # aff tag linked via an rid to id attribute
+        ('''<aff id="aff1">
+<label>1</label>
+<institution content-type="dept">Department of Production</institution>
+<institution>eLife</institution>
+<addr-line>
+<named-content content-type="city">Cambridge</named-content>
+</addr-line>
+<country>United Kingdom</country>
+</aff>''',
+        ('aff1', {
+            'city': u'Cambridge',
+            'country': u'United Kingdom',
+            'dept': u'Department of Production',
+            'institution': u'eLife'}
+         )
+        ),
+        # inline aff tag example, no id attribute
+        ('''<aff>
+<institution>eLife</institution>
+<addr-line>
+<named-content content-type="city">Cambridge</named-content>
+</addr-line>
+<country>United Kingdom</country>
+</aff>''',
+        (None, {
+            'country': u'United Kingdom',
+            'institution': u'eLife',
+            'city': u'Cambridge'}
+         )
+        ),
+        # edge case, no aff tag or the rid idoes not match an aff id
+        (None,
+        (None, {})
+        ),
+    )
+    @unpack
+    def test_format_aff_edge_cases(self, xml_content, expected):
+        if xml_content:
+            soup = parser.parse_xml(xml_content)
+            aff_tag = soup.contents[0]
+        else:
+            # where the tag is None
+            aff_tag = xml_content
+        tag_content = parser.format_aff(aff_tag)
+        self.assertEqual(expected, tag_content)
+
+
     @unpack
     @data(
         (None, []),


### PR DESCRIPTION
If you would like to please review, and if you look at this and approve it before PR https://github.com/elifesciences/elife-tools/pull/253, I have another edge case test I can add for format_contributors() (introduced in PR #235) with an example for when the ``<aff>`` tag cannot be found for a ``<contrib>`` tag.