### PR TITLE
Shift around some functions to avoid circular imports in json_rewrite.py

### DIFF
--- a/elifetools/json_rewrite.py
+++ b/elifetools/json_rewrite.py
@@ -3,8 +3,9 @@
 from collections import OrderedDict
 from six import iteritems
 
-import elifetools.parseJATS 
+import elifetools.rawJATS
 import elifetools.utils
+import elifetools.utils_html
 
 def rewrite_json(rewrite_type, soup, json_content):
     """
@@ -13,15 +14,19 @@ def rewrite_json(rewrite_type, soup, json_content):
     """
     if not soup:
         return json_content
-    if not elifetools.parseJATS.doi(soup) or not elifetools.parseJATS.journal_id(soup):
+    if not elifetools.rawJATS.doi(soup) or not elifetools.rawJATS.journal_id(soup):
         return json_content
 
     # Hook only onto elife articles for rewriting currently
-    if elifetools.parseJATS.journal_id(soup).lower() == "elife":
-        function_name = rewrite_function_name(elifetools.parseJATS.journal_id(soup), rewrite_type)
+    journal_id_tag = elifetools.rawJATS.journal_id(soup)
+    doi_tag = elifetools.rawJATS.doi(soup)
+    journal_id = elifetools.utils.node_text(journal_id_tag)
+    doi = elifetools.utils.doi_uri_to_doi(elifetools.utils.node_text(doi_tag))
+    if journal_id.lower() == "elife":
+        function_name = rewrite_function_name(journal_id, rewrite_type)
         if function_name:
             try:
-                json_content = globals()[function_name](json_content, elifetools.parseJATS.doi(soup))
+                json_content = globals()[function_name](json_content, doi)
             except KeyError:
                 pass
     return json_content
@@ -366,9 +371,9 @@ def elife_references_rewrite_json():
         ref_json[id][author_type] = []
         for ref_author in authors:
             if  "collab" in ref_author:
-                author_json = elifetools.parseJATS.references_author_collab(ref_author)
+                author_json = elifetools.utils_html.references_author_collab(ref_author)
             else:
-                author_json = elifetools.parseJATS.references_author_person(ref_author)
+                author_json = elifetools.utils.references_author_person(ref_author)
             if author_json:
                 ref_json[id][author_type].append(author_json)
         # Add to json array, and do not verwrite existing rule of a specific bib id (if present)

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -7,7 +7,7 @@ import elifetools.rawJATS as raw_parser
 import elifetools.json_rewrite
 from elifetools.utils import *
 from elifetools.utils import unicode_value
-from elifetools.utils_html import xml_to_html
+from elifetools.utils_html import xml_to_html, references_author_collab
 
 
 def parse_xml(xml):
@@ -2647,14 +2647,6 @@ def digest_json(soup):
     return abstract_json
 
 
-def author_preferred_name(surname, given_names, suffix):
-    return " ".join([element for element in [given_names, surname, suffix] if element is not None])
-
-
-def author_index_name(surname, given_names, suffix):
-    index_name = ", ".join([element for element in [surname, given_names, suffix] if element is not None])
-    return index_name
-
 def author_affiliations(author, html_flag=True):
     """compile author affiliations for json output"""
 
@@ -3099,28 +3091,6 @@ def references_date(year=None):
         else:
             date = year
     return (date, discriminator, in_press)
-
-def references_author_collab(ref_author, html_flag=True):
-    # Configure the XML to HTML conversion preference for shorthand use below
-    convert = lambda xml_string: xml_to_html(html_flag, xml_string)
-
-    author_json = OrderedDict()
-    author_json["type"] = "group"
-    author_json["name"] = unicode_value(convert(ref_author.get("collab")))
-    return author_json
-
-def references_author_person(ref_author):
-    author_json = OrderedDict()
-    author_json["type"] = "person"
-    author_name = OrderedDict()
-    author_name["preferred"] = author_preferred_name(ref_author.get("surname"),
-                                                     ref_author.get("given-names"),
-                                                     ref_author.get("suffix"))
-    author_name["index"] = author_index_name(ref_author.get("surname"),
-                                             ref_author.get("given-names"),
-                                             ref_author.get("suffix"))
-    author_json["name"] = author_name
-    return author_json
 
 def references_authors(ref_authors):
     all_authors = OrderedDict()

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -1,6 +1,7 @@
 import time
 import calendar
 import re
+from collections import OrderedDict
 from six import iteritems
 
 
@@ -501,3 +502,23 @@ def escape_ampersand(string):
     # The pattern below is match & that is not immediately followed by #
     string = re.sub(r"&(?!" + start_with_match + ")", '&amp;', string)
     return string
+
+def references_author_person(ref_author):
+    author_json = OrderedDict()
+    author_json["type"] = "person"
+    author_name = OrderedDict()
+    author_name["preferred"] = author_preferred_name(ref_author.get("surname"),
+                                                     ref_author.get("given-names"),
+                                                     ref_author.get("suffix"))
+    author_name["index"] = author_index_name(ref_author.get("surname"),
+                                             ref_author.get("given-names"),
+                                             ref_author.get("suffix"))
+    author_json["name"] = author_name
+    return author_json
+
+def author_preferred_name(surname, given_names, suffix):
+    return " ".join([element for element in [given_names, surname, suffix] if element is not None])
+
+def author_index_name(surname, given_names, suffix):
+    index_name = ", ".join([element for element in [surname, given_names, suffix] if element is not None])
+    return index_name

--- a/elifetools/utils_html.py
+++ b/elifetools/utils_html.py
@@ -1,5 +1,6 @@
 import re
-from elifetools.utils import escape_unmatched_angle_brackets, escape_ampersand
+from collections import OrderedDict
+from elifetools.utils import escape_unmatched_angle_brackets, escape_ampersand, unicode_value
 
 def xml_to_html(html_flag, xml_string, base_url=None):
     "For formatting json output into HTML friendly format"
@@ -202,3 +203,12 @@ def replace_table_style_author_callout(s):
             old_tag = tag_start + 'style="' + class_name + '"' + tag_end
             s = s.replace(old_tag, new_tag)
     return s
+
+def references_author_collab(ref_author, html_flag=True):
+    # Configure the XML to HTML conversion preference for shorthand use below
+    convert = lambda xml_string: xml_to_html(html_flag, xml_string)
+
+    author_json = OrderedDict()
+    author_json["type"] = "group"
+    author_json["name"] = unicode_value(convert(ref_author.get("collab")))
+    return author_json


### PR DESCRIPTION
Turned out to be a little more complicated than I expected to move functions out of parseJATS, to get the circular imports in json_rewrite removed. The tests pass, and this small refactor may help with integrating elife-tools with other projects.