### PR TITLE
Feature boxed text inline graphic

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2009,6 +2009,24 @@ def research_organism_json(soup, html_flag=True):
     research_organisms = list(filter(lambda term: term and term.lower() not in do_not_include, full_research_organism(soup)))
     return list(map(convert, research_organisms))
 
+def boxed_text_to_image_block(tag):
+    "covert boxed-text to an image block containing an inline-graphic"
+    tag_block = OrderedDict()
+    image_content = body_block_image_content(first(raw_parser.inline_graphic(tag)))
+    tag_block["type"] = "image"
+    set_if_value(tag_block, "doi", doi_uri_to_doi(object_id_doi(tag, tag.name)))
+    set_if_value(tag_block, "id", tag.get("id"))
+    set_if_value(tag_block, "image", image_content)
+    # render paragraphs into a caption
+    p_tags = raw_parser.paragraph(tag)
+    caption_content = []
+    for p_tag in p_tags:
+        if not raw_parser.inline_graphic(p_tag):
+            caption_content.append(body_block_content(p_tag))
+    set_if_value(tag_block, "caption", caption_content)
+    return tag_block
+
+
 def body(soup, remove_key_info_box=False, base_url=None):
 
     body_content = []
@@ -2056,6 +2074,11 @@ def render_raw_body(tag, remove_key_info_box=False, base_url=None):
                 and "related" in first_node_text.lower()):
                 # Skip this tag
                 continue
+
+            elif raw_parser.inline_graphic(tag):
+                # edge case where inline-graphic is in the first boxed-text
+                tag_block = boxed_text_to_image_block(tag)
+                body_content.append(tag_block)
 
             elif not raw_parser.title(tag) and not raw_parser.label(tag):
                 # Collapse boxed-text here if it has no title or label
@@ -2219,6 +2242,16 @@ def body_block_paragraph_content(text):
         tag_content["type"] = "paragraph"
         tag_content["text"] = clean_whitespace(text)
     return tag_content
+
+def body_block_image_content(tag):
+    "format a graphic or inline-graphic into a body block json format"
+    image_content = {}
+    if tag:
+        copy_attribute(tag.attrs, 'xlink:href', image_content, 'uri')
+        if "uri" in image_content:
+            # todo!! alt
+            set_if_value(image_content, "alt", "")
+    return image_content
 
 def body_block_title_label_caption(tag_content, title_value, label_value,
                                    caption_content, set_caption=True, prefer_title=False, prefer_label=False):
@@ -2385,13 +2418,8 @@ def body_block_content(tag, html_flag=True, base_url=None):
         body_block_title_label_caption(asset_tag_content, title_value, label_value, caption_content, set_caption=True)
 
         if raw_parser.graphic(tag):
-            image_content = {}
             graphic_tags = raw_parser.graphic(tag)
-            if graphic_tags:
-                copy_attribute(first(graphic_tags).attrs, 'xlink:href', image_content, 'uri')
-                if "uri" in image_content:
-                    # todo!! alt
-                    set_if_value(image_content, "alt", "")
+            image_content = body_block_image_content(first(graphic_tags))
             if len(image_content) > 0:
                 asset_tag_content["image"] = image_content
 

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -846,7 +846,29 @@ class TestParseJats(unittest.TestCase):
 
         # 00646 v1 boxed text to keep, and wrap in section
         ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><article><body><boxed-text id="B1"><p>This article by Emma Pewsey (pictured) was the winning entry in the <ext-link ext-link-type="uri" xlink:href="http://europepmc.org/ScienceWritingCompetition">Access to Understanding science-writing competition</ext-link> for PhD students and early career post-doctoral researchers organized by Europe PubMed Central in partnership with The British Library. Entrants were asked to explain to a non-scientific audience, in fewer than 800 words, the research reported in a scientific article and why it mattered.</p><p><inline-graphic xlink:href="elife-00646-inf1-v1"/></p></boxed-text><p>Normal healthy bones can be thought of as nature\'s scaffold poles. The tightly packed minerals that make up the cortical bone form a sheath around an inner core of spongy bone and provide the strength that supports our bodies. Throughout our lives, our skeletons are kept strong by the continuous creation of new, fresh bone and the destruction of old, worn out bone. Unfortunately, as we become older, destruction becomes faster than creation, and so the cortical layer thins, causing the bone to weaken and break more easily. In severe cases, this is known as osteoporosis. As a result, simple trips or falls that would only bruise a younger person can cause serious fractures in the elderly. However, half of the elderly patients admitted to hospital with a broken hip do not suffer from osteoporosis.</p></body></article></root>',
-        [OrderedDict([('type', 'section'), ('id', 's0'), ('title', 'Main text'), ('content', [OrderedDict([('type', 'paragraph'), ('text', 'This article by Emma Pewsey (pictured) was the winning entry in the <a href="http://europepmc.org/ScienceWritingCompetition">Access to Understanding science-writing competition</a> for PhD students and early career post-doctoral researchers organized by Europe PubMed Central in partnership with The British Library. Entrants were asked to explain to a non-scientific audience, in fewer than 800 words, the research reported in a scientific article and why it mattered.')]), OrderedDict([('type', 'paragraph'), ('text', '<img src="elife-00646-inf1-v1.jpg"/>')]), OrderedDict([('type', 'paragraph'), ('text', u"Normal healthy bones can be thought of as nature's scaffold poles. The tightly packed minerals that make up the cortical bone form a sheath around an inner core of spongy bone and provide the strength that supports our bodies. Throughout our lives, our skeletons are kept strong by the continuous creation of new, fresh bone and the destruction of old, worn out bone. Unfortunately, as we become older, destruction becomes faster than creation, and so the cortical layer thins, causing the bone to weaken and break more easily. In severe cases, this is known as osteoporosis. As a result, simple trips or falls that would only bruise a younger person can cause serious fractures in the elderly. However, half of the elderly patients admitted to hospital with a broken hip do not suffer from osteoporosis.")])])])]
+        [
+            OrderedDict([
+                ('type', 'section'),
+                ('id', 's0'),
+                ('title', 'Main text'),
+                ('content', [
+                    OrderedDict([
+                        ('type', 'image'),
+                        ('id', u'B1'),
+                        ('image', {'alt': '', 'uri': u'elife-00646-inf1-v1'}),
+                        ('caption', [
+                            OrderedDict([
+                                ('type', 'paragraph'),
+                                ('text', 'This article by Emma Pewsey (pictured) was the winning entry in the <a href="http://europepmc.org/ScienceWritingCompetition">Access to Understanding science-writing competition</a> for PhD students and early career post-doctoral researchers organized by Europe PubMed Central in partnership with The British Library. Entrants were asked to explain to a non-scientific audience, in fewer than 800 words, the research reported in a scientific article and why it mattered.')
+                            ])
+                        ])
+                    ]), OrderedDict([
+                        ('type', 'paragraph'),
+                        ('text', u"Normal healthy bones can be thought of as nature's scaffold poles. The tightly packed minerals that make up the cortical bone form a sheath around an inner core of spongy bone and provide the strength that supports our bodies. Throughout our lives, our skeletons are kept strong by the continuous creation of new, fresh bone and the destruction of old, worn out bone. Unfortunately, as we become older, destruction becomes faster than creation, and so the cortical layer thins, causing the bone to weaken and break more easily. In severe cases, this is known as osteoporosis. As a result, simple trips or falls that would only bruise a younger person can cause serious fractures in the elderly. However, half of the elderly patients admitted to hospital with a broken hip do not suffer from osteoporosis.")
+                    ])
+                ])
+            ])
+        ]
          ),
 
         # 02945 v1, correction article keep the boxed-text
@@ -2527,11 +2549,28 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
         [OrderedDict([('type', 'paragraph'), ('text', u'Content.')]), OrderedDict([('type', 'figure'), ('assets', [OrderedDict([('type', 'image'), ('doi', u'10.7554/eLife.00666.008'), ('id', u'fig2'), ('label', u'Figure 2'), ('title', u'Figure title'), ('caption', [OrderedDict([('type', 'paragraph'), ('text', u'Figure caption')])]), ('image', {'alt': '', 'uri': u'elife-00666-fig2-v1.tif'})]), OrderedDict([('type', 'image'), ('doi', u'10.7554/eLife.00666.009'), ('id', u'fig2s1'), ('label', u'Figure 2'), ('title', u'Figure title'), ('caption', [OrderedDict([('type', 'paragraph'), ('text', u'Figure caption')])]), ('image', {'alt': '', 'uri': u'elife-00666-fig2-figsupp1-v1.tif'})])])]), OrderedDict([('type', 'paragraph'), ('text', u'More content')])]
          ),
 
-        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p><boxed-text id="B1"><p>Boxed text with no title</p></boxed-text></p></body></root>',
-        [OrderedDict([('content', [OrderedDict([('type', 'box'), ('id', u'B1'), ('content', [OrderedDict([('type', 'paragraph'), ('text', u'Boxed text with no title')])])])])])]
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><p><boxed-text id="B1"><p>Boxed text with no title</p></boxed-text></p></root>',
+        [OrderedDict([('type', 'box'), ('id', u'B1'), ('content', [OrderedDict([('type', 'paragraph'), ('text', u'Boxed text with no title')])])])]
          ),
 
-        )
+        # excerpt from 00646 v1 with a boxed-text inline-graphic
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><boxed-text id="B1"><p>This article by Emma Pewsey (pictured) was the winning entry in the <ext-link ext-link-type="uri" xlink:href="http://europepmc.org/ScienceWritingCompetition">Access to Understanding science-writing competition</ext-link> for PhD students and early career post-doctoral researchers organized by Europe PubMed Central in partnership with The British Library. Entrants were asked to explain to a non-scientific audience, in fewer than 800 words, the research reported in a scientific article and why it mattered.</p><p><inline-graphic xlink:href="elife-00646-inf1-v1"/></p></boxed-text></root>',
+        [
+            OrderedDict([
+                ('type', 'image'),
+                ('id', u'B1'),
+                ('image', {'alt': '', 'uri': u'elife-00646-inf1-v1'}),
+                ('caption', [
+                    OrderedDict([
+                        ('type', 'paragraph'),
+                        ('text', 'This article by Emma Pewsey (pictured) was the winning entry in the <a href="http://europepmc.org/ScienceWritingCompetition">Access to Understanding science-writing competition</a> for PhD students and early career post-doctoral researchers organized by Europe PubMed Central in partnership with The British Library. Entrants were asked to explain to a non-scientific audience, in fewer than 800 words, the research reported in a scientific article and why it mattered.')
+                    ])
+                ])
+            ])
+        ]
+
+        ),
+    )
     def test_render_raw_body(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)
         tag_content = parser.render_raw_body(soup.contents[0])


### PR DESCRIPTION
Fix for bug described in https://elifesciences.atlassian.net/browse/ELPP-3312. 

The new code will be invoked for a few articles which have a ``<boxed-text>`` tag as the first tag in the ``<body>``, only if there is an ``<inline-graphic>`` tag inside. Instead of the content being converted to boring paragraph blocks, it will generate an exciting image block where the inline-graphic is the image, and the paragraphs (which do not include the inline-graphic) will be used as its caption content.

I will merge this if code tests pass without code review in order to see which articles it might fail on when testing against the entire eLife corpus.