### PR TITLE
Explicitly read files in binary mode.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -14,7 +14,7 @@ def parse_xml(xml):
     return BeautifulSoup(xml, "lxml-xml")
 
 def parse_document(filelocation):
-    with open(filelocation) as fp:
+    with open(filelocation, 'rb') as fp:
         return parse_xml(fp)
 
 def duplicate_tag(tag):


### PR DESCRIPTION
Earlier I had errors running tests in Python 3. I tried tox today and the huge volume of errors running tests (on Windows) is solved when files are read in binary mode. I'm imagining other environments will not have an issue with this change.