### PR TITLE
Can use BytesIO instead of StringIO in tests for Python 2 and 3.

### DIFF
--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -1,11 +1,6 @@
 from __future__ import absolute_import
 
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
+from io import BytesIO
 import unittest
 
 from ddt import ddt, data, unpack
@@ -74,7 +69,7 @@ class TestXmlio(unittest.TestCase):
     @data(("<article/>", "JATS", '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1d3 20150301//EN"  "JATS-archivearticle1.dtd"><article/>'),
         ("<article/>", None, '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article><article/>'))
     def test_output(self, xml, type, xml_expected):
-        root = xmlio.parse(StringIO(xml))
+        root = xmlio.parse(BytesIO(xml))
         xml_output = xmlio.output(root, type)
         self.assertEqual(xml_output.decode('utf-8'), xml_expected)
 
@@ -90,7 +85,7 @@ class TestXmlio(unittest.TestCase):
     def test_output_root(self, xml, publicId, systemId, internalSubset, xml_expected):
         encoding = 'UTF-8'
         qualifiedName = "article"
-        root = xmlio.parse(StringIO(xml))
+        root = xmlio.parse(BytesIO(xml))
         doctype = xmlio.build_doctype(qualifiedName, publicId, systemId, internalSubset)
         xml_output = xmlio.output_root(root, doctype, encoding)
         self.assertEqual(xml_output.decode('utf-8'), xml_expected)

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from io import BytesIO
+from io import StringIO
 import unittest
 
 from ddt import ddt, data, unpack
@@ -66,26 +66,26 @@ class TestXmlio(unittest.TestCase):
         self.assertEqual(xml_output, xml_output_expected)
 
     @unpack
-    @data(("<article/>", "JATS", '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1d3 20150301//EN"  "JATS-archivearticle1.dtd"><article/>'),
-        ("<article/>", None, '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article><article/>'))
+    @data((u"<article/>", "JATS", '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1d3 20150301//EN"  "JATS-archivearticle1.dtd"><article/>'),
+        (u"<article/>", None, '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article><article/>'))
     def test_output(self, xml, type, xml_expected):
-        root = xmlio.parse(BytesIO(xml))
+        root = xmlio.parse(StringIO(xml))
         xml_output = xmlio.output(root, type)
         self.assertEqual(xml_output.decode('utf-8'), xml_expected)
 
     @unpack
-    @data(("<article/>", "", "", None,
+    @data((u"<article/>", "", "", None,
            '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article><article/>'),
-        ("<article/>", "-//a", "a", None,
+        (u"<article/>", "-//a", "a", None,
          '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//a"  "a"><article/>'),
-        ("<article/>", None, "b", "",
+        (u"<article/>", None, "b", "",
          '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article SYSTEM "b"><article/>'),
-        ("<article/>", "c", "", "subset",
+        (u"<article/>", "c", "", "subset",
          '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "c"  "" [subset]><article/>'))
     def test_output_root(self, xml, publicId, systemId, internalSubset, xml_expected):
         encoding = 'UTF-8'
         qualifiedName = "article"
-        root = xmlio.parse(BytesIO(xml))
+        root = xmlio.parse(StringIO(xml))
         doctype = xmlio.build_doctype(qualifiedName, publicId, systemId, internalSubset)
         xml_output = xmlio.output_root(root, doctype, encoding)
         self.assertEqual(xml_output.decode('utf-8'), xml_expected)


### PR DESCRIPTION
Expanding the ``xmlio.py`` functions for subject rewriting, this is the only place ``StringIO`` was used, and it can be substituted with ``BytesIO``.