### PR TITLE
Feature figure attribution

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2271,6 +2271,28 @@ def body_block_title_label_caption(tag_content, title_value, label_value,
             set_if_value(tag_content, "label", rstrip_punctuation(title_value))
             del(tag_content["title"])
 
+def body_block_attribution(tag):
+    "extract the attribution content for figures, tables, videos"
+    attributions = []
+    if raw_parser.attrib(tag):
+        for attrib_tag in raw_parser.attrib(tag):
+            attributions.append(node_contents_str(attrib_tag))
+    if raw_parser.permissions(tag):
+        # concatenate content from from the permissions tag
+        for permissions_tag in raw_parser.permissions(tag):
+            attrib_string = ''
+            # add the copyright statement if found
+            attrib_string = join_sentences(attrib_string,
+                node_contents_str(raw_parser.copyright_statement(permissions_tag)), '.')
+            # add the license paragraphs
+            if raw_parser.licence_p(permissions_tag):
+                for licence_p_tag in raw_parser.licence_p(permissions_tag):
+                    attrib_string = join_sentences(attrib_string,
+                                                   node_contents_str(licence_p_tag), '.')
+            if attrib_string != '':
+                attributions.append(attrib_string)
+    return attributions
+
 def body_block_content(tag, html_flag=True, base_url=None):
     # Configure the XML to HTML conversion preference for shorthand use below
     convert = lambda xml_string: xml_to_html(html_flag, xml_string, base_url)
@@ -2423,24 +2445,8 @@ def body_block_content(tag, html_flag=True, base_url=None):
                 asset_tag_content["image"] = image_content
 
         # license or attribution
-        attributions = []
-        if raw_parser.attrib(tag):
-            for attrib_tag in raw_parser.attrib(tag):
-                attributions.append(node_contents_str(attrib_tag))
-        if raw_parser.permissions(tag):
-            # concatenate content from from the permissions tag
-            for permissions_tag in raw_parser.permissions(tag):
-                attrib_string = ''
-                # add the copyright statement if found
-                attrib_string = join_sentences(attrib_string,
-                    node_contents_str(raw_parser.copyright_statement(permissions_tag)), '.')
-                if raw_parser.licence_p(permissions_tag):
-                    for licence_p_tag in raw_parser.licence_p(permissions_tag):
-                        attrib_string = join_sentences(attrib_string,
-                                                       node_contents_str(licence_p_tag), '.')
-                if attrib_string != '':
-                    attributions.append(attrib_string)
-        if len(attributions) > 0:
+        attributions = body_block_attribution(tag)
+        if attributions:
             asset_tag_content["image"]["attribution"] = []
             for attrib_string in attributions:
                 asset_tag_content["image"]["attribution"].append(convert(attrib_string))

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2427,9 +2427,23 @@ def body_block_content(tag, html_flag=True, base_url=None):
         if raw_parser.attrib(tag):
             for attrib_tag in raw_parser.attrib(tag):
                 attributions.append(node_contents_str(attrib_tag))
-        if raw_parser.licence(tag) and raw_parser.licence_p(tag):
-            for attrib_tag in raw_parser.licence_p(tag):
-                attributions.append(node_contents_str(attrib_tag))
+        if raw_parser.permissions(tag):
+            # concatenate content from from the permissions tag
+            for permissions_tag in raw_parser.permissions(tag):
+                attrib_string = ''
+                if raw_parser.copyright_statement(permissions_tag):
+                    attrib_string += node_contents_str(raw_parser.copyright_statement(permissions_tag))
+                if raw_parser.licence(permissions_tag) and raw_parser.licence_p(permissions_tag):
+                    # fix punctuation of the copyright statement if it is missing
+                    if attrib_string != '':
+                        if not attrib_string.rstrip().endswith('.'):
+                            attrib_string += '. '
+                        elif attrib_string.endswith('.'):
+                            attrib_string += ' '
+                    for licence_p_tag in raw_parser.licence_p(permissions_tag):
+                        attrib_string += node_contents_str(licence_p_tag)
+                if attrib_string != '':
+                    attributions.append(attrib_string)
         if len(attributions) > 0:
             asset_tag_content["image"]["attribution"] = []
             for attrib_string in attributions:

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2487,6 +2487,13 @@ def body_block_content(tag, html_flag=True, base_url=None):
             caption_content, supplementary_material_tags = body_block_caption_render(caption_tags, base_url=base_url)
         body_block_title_label_caption(asset_tag_content, title_value, label_value, caption_content, set_caption=True)
 
+        # license or attribution
+        attributions = body_block_attribution(tag)
+        if attributions:
+            asset_tag_content["attribution"] = []
+            for attrib_string in attributions:
+                asset_tag_content["attribution"].append(convert(attrib_string))
+
         set_if_value(asset_tag_content, "uri", tag.get('xlink:href'))
         if "uri" in asset_tag_content and asset_tag_content["uri"].endswith('.gif'):
             asset_tag_content["autoplay"] = True

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2431,17 +2431,13 @@ def body_block_content(tag, html_flag=True, base_url=None):
             # concatenate content from from the permissions tag
             for permissions_tag in raw_parser.permissions(tag):
                 attrib_string = ''
-                if raw_parser.copyright_statement(permissions_tag):
-                    attrib_string += node_contents_str(raw_parser.copyright_statement(permissions_tag))
-                if raw_parser.licence(permissions_tag) and raw_parser.licence_p(permissions_tag):
-                    # fix punctuation of the copyright statement if it is missing
-                    if attrib_string != '':
-                        if not attrib_string.rstrip().endswith('.'):
-                            attrib_string += '. '
-                        elif attrib_string.endswith('.'):
-                            attrib_string += ' '
+                # add the copyright statement if found
+                attrib_string = join_sentences(attrib_string,
+                    node_contents_str(raw_parser.copyright_statement(permissions_tag)), '.')
+                if raw_parser.licence_p(permissions_tag):
                     for licence_p_tag in raw_parser.licence_p(permissions_tag):
-                        attrib_string += node_contents_str(licence_p_tag)
+                        attrib_string = join_sentences(attrib_string,
+                                                       node_contents_str(licence_p_tag), '.')
                 if attrib_string != '':
                     attributions.append(attrib_string)
         if len(attributions) > 0:

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -2016,6 +2016,25 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
             ])
         ])),
 
+         # example of video with attributions, based on article 17243
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><media content-type="glencoe play-in-place height-250 width-310" id="media1" mime-subtype="mp4" mimetype="video" xlink:href="elife-17243-media1.mp4"><object-id pub-id-type="doi">10.7554/eLife.17243.015</object-id><label>Video 1.</label><caption><title>Response to gaps (stimulus-reappearance lock).</title><p><bold>DOI:</bold><ext-link ext-link-type="doi" xlink:href="10.7554/eLife.17243.015">http://dx.doi.org/10.7554/eLife.17243.015</ext-link></p></caption><permissions><license><license-p>Face photographs: Owen Lucas. Available on Flickr under the Public Domain Mark 1.0 <ext-link ext-link-type="uri" xlink:href="https://creativecommons.org/publicdomain/mark/1.0/">https://creativecommons.org/publicdomain/mark/1.0/</ext-link>). <ext-link ext-link-type="uri" xlink:href="https://www.flickr.com/photos/144006675@N05/27487033282">https://www.flickr.com/photos/144006675@N05/27487033282</ext-link>. Accessed on August 2016.</license-p></license></permissions></media></root>',
+         OrderedDict([
+            ('type', 'figure'),
+            ('assets', [
+                OrderedDict([
+                    ('type', 'video'),
+                    ('doi', u'10.7554/eLife.17243.015'),
+                    ('id', u'media1'),
+                    ('label', u'Video 1'),
+                    ('title', u'Response to gaps (stimulus-reappearance lock).'),
+                    ('attribution', [
+                        'Face photographs: Owen Lucas. Available on Flickr under the Public Domain Mark 1.0 <a href="https://creativecommons.org/publicdomain/mark/1.0/">https://creativecommons.org/publicdomain/mark/1.0/</a>). <a href="https://www.flickr.com/photos/144006675@N05/27487033282">https://www.flickr.com/photos/144006675@N05/27487033282</a>. Accessed on August 2016.'
+                    ]),
+                    ('uri', u'elife-17243-media1.mp4')
+                ])
+            ])
+        ])),
+
         ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><fig id="fig3s1" position="float" specific-use="child-fig"><object-id pub-id-type="doi">10.7554/eLife.00666.012</object-id><label>Figure 3—figure supplement 1.</label><caption><title>Title of the figure supplement</title><p><supplementary-material id="SD1-data"><object-id pub-id-type="doi">10.7554/eLife.00666.013</object-id><label>Figure 3—figure supplement 1—Source data 1.</label><caption><title>Title of the figure supplement source data.</title><p>Legend of the figure supplement source data.</p></caption><media mime-subtype="xlsx" mimetype="application" xlink:href="elife-00666-fig3-figsupp1-data1-v1.xlsx"/></supplementary-material></p></caption><graphic xlink:href="elife-00666-fig3-figsupp1-v1.tiff"/></fig></root>',
         OrderedDict([('type', 'figure'), ('assets', [OrderedDict([('type', 'image'), ('doi', u'10.7554/eLife.00666.012'), ('id', u'fig3s1'), ('label', u'Figure 3\u2014figure supplement 1'), ('title', u'Title of the figure supplement'), ('image', {'alt': '', 'uri': u'elife-00666-fig3-figsupp1-v1.tiff'}), ('sourceData', [OrderedDict([('doi', u'10.7554/eLife.00666.013'), ('id', u'SD1-data'), ('label', u'Figure 3\u2014figure supplement 1\u2014Source data 1'), ('title', u'Title of the figure supplement source data.'), ('caption', [OrderedDict([('type', 'paragraph'), ('text', u'Legend of the figure supplement source data.')])]), ('mediaType', u'application/xlsx'), ('uri', u'elife-00666-fig3-figsupp1-data1-v1.xlsx'), ('filename', u'elife-00666-fig3-figsupp1-data1-v1.xlsx')])])])])])
          ),

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1977,13 +1977,44 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
                      ('type', 'paragraph'),
                      ('text', u'Figure caption')
                  ])]),
-                 ('image', {
-                     'alt': '',
-                     'uri': u'elife-00666-fig1-v1.tif',
-                     'attribution': ['The in situ image in panel 3 is reprinted with permission from Figure 2D, <a href="#bib72">Small et al. (1991)</a>, <i>Test &amp; Automated</i>.', 'In situ images in panels 4 and 5 are reprinted with permission from Figure 3A and 3C, <a href="#bib74">Stanojevic et al. (1991)</a>, <i>Journal</i>.']
-                 }),
+                 ('image', OrderedDict([
+                     ('uri', u'elife-00666-fig1-v1.tif'),
+                     ('alt', u''),
+                     ('attribution', [
+                        u'\u00a9 1991, Publisher 1, All Rights Reserved. The in situ image in panel 3 is reprinted with permission from Figure 2D, <a href="#bib72">Small et al. (1991)</a>, <i>Test &amp; Automated</i>.', 
+                        u'\u00a9 1991, Publisher 2, All Rights Reserved. In situ images in panels 4 and 5 are reprinted with permission from Figure 3A and 3C, <a href="#bib74">Stanojevic et al. (1991)</a>, <i>Journal</i>.'
+                    ])
+                 ])),
              ])])
          ])),
+
+        # example of copyright statements ending in a full stop, based on article 27041
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><fig id="fig3" position="float"><object-id pub-id-type="doi">10.7554/eLife.27041.006</object-id><label>Figure 3.</label><caption><title>Developmental trajectories.</title><p>Each plot shows single cells (dots; colored by trajectory assignment, sampled time point, or developmental stage) embedded in low-dimensional space based on their RNA (<bold>A-C</bold>) or protein (<bold>D</bold>) profiles, using different methods for dimensionality reduction and embedding: Gaussian process patent variable model (<bold>A</bold>); t-stochastic neighborhood embedding (<bold>B</bold>, <bold>D</bold>); diffusion maps (<bold>C</bold>). Computational methods then identify trajectories of pseudo-temporal progression in each case. (<bold>A</bold>) Myoblast differentiation in vitro. (<bold>B</bold>) Neurogenesis in the mouse brain dentate gyrus. (<bold>C</bold>) Embryonic stem cell differentiation in vitro. (<bold>D</bold>) Early hematopoiesis.</p></caption><graphic mime-subtype="postscript" mimetype="application" xlink:href="elife-27041-fig3-v2"/><permissions><copyright-statement>© 2017 AAAS.</copyright-statement><copyright-year>2017</copyright-year><copyright-holder>AAAS</copyright-holder><license><license-p><xref ref-type="fig" rid="fig3">Figure 3A</xref> reprinted from <xref ref-type="bibr" rid="bib109">Lönnberg et al., 2017</xref> with permission.</license-p></license></permissions><permissions><copyright-statement>© 2016 AAAS.</copyright-statement><copyright-year>2016</copyright-year><copyright-holder>AAAS</copyright-holder><license><license-p><xref ref-type="fig" rid="fig3">Figure 3B</xref> reprinted from <xref ref-type="bibr" rid="bib67">Habib et al., 2016a</xref> with permission.</license-p></license></permissions><permissions><copyright-statement>© 2016 Macmillan Publishers Limited. </copyright-statement><copyright-year>2016</copyright-year><copyright-holder>Macmillan Publishers Limited</copyright-holder><license><license-p><xref ref-type="fig" rid="fig3">Figure 3C</xref> adapted from <xref ref-type="bibr" rid="bib70">Haghverdi et al., 2016</xref> with permission.</license-p></license></permissions><permissions><copyright-statement>© 2016 Macmillan Publishers Limited.</copyright-statement><copyright-year>2016</copyright-year><copyright-holder>Macmillan Publishers Limited</copyright-holder><license><license-p><xref ref-type="fig" rid="fig3">Figure 3D</xref> adapted from <xref ref-type="bibr" rid="bib157">Setty et al., 2016</xref> with permission.</license-p></license></permissions></fig></root>',
+         OrderedDict([
+            ('type', 'figure'),
+            ('assets', [
+                OrderedDict([
+                    ('type', 'image'),
+                    ('doi', u'10.7554/eLife.27041.006'),
+                    ('id', u'fig3'),
+                    ('label', u'Figure 3'),
+                    ('title', u'Developmental trajectories.'),
+                    ('caption', [
+                        OrderedDict([
+                            ('type', 'paragraph'),
+                            ('text', u'Each plot shows single cells (dots; colored by trajectory assignment, sampled time point, or developmental stage) embedded in low-dimensional space based on their RNA (<b>A-C</b>) or protein (<b>D</b>) profiles, using different methods for dimensionality reduction and embedding: Gaussian process patent variable model (<b>A</b>); t-stochastic neighborhood embedding (<b>B</b>, <b>D</b>); diffusion maps (<b>C</b>). Computational methods then identify trajectories of pseudo-temporal progression in each case. (<b>A</b>) Myoblast differentiation in vitro. (<b>B</b>) Neurogenesis in the mouse brain dentate gyrus. (<b>C</b>) Embryonic stem cell differentiation in vitro. (<b>D</b>) Early hematopoiesis.')
+                        ])
+                    ]),
+                    ('image', OrderedDict([
+                        ('uri', u'elife-27041-fig3-v2'),
+                        ('alt', ''),
+                        ('attribution', [
+                            u'\xa9 2017 AAAS. <a href="#fig3">Figure 3A</a> reprinted from <a href="#bib109">L\xf6nnberg et al., 2017</a> with permission.', u'\xa9 2016 AAAS. <a href="#fig3">Figure 3B</a> reprinted from <a href="#bib67">Habib et al., 2016a</a> with permission.', u'\xa9 2016 Macmillan Publishers Limited. <a href="#fig3">Figure 3C</a> adapted from <a href="#bib70">Haghverdi et al., 2016</a> with permission.', u'\xa9 2016 Macmillan Publishers Limited. <a href="#fig3">Figure 3D</a> adapted from <a href="#bib157">Setty et al., 2016</a> with permission.'
+                        ])
+                    ]))
+                ])
+            ])
+        ])),
 
         ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><fig id="fig3s1" position="float" specific-use="child-fig"><object-id pub-id-type="doi">10.7554/eLife.00666.012</object-id><label>Figure 3—figure supplement 1.</label><caption><title>Title of the figure supplement</title><p><supplementary-material id="SD1-data"><object-id pub-id-type="doi">10.7554/eLife.00666.013</object-id><label>Figure 3—figure supplement 1—Source data 1.</label><caption><title>Title of the figure supplement source data.</title><p>Legend of the figure supplement source data.</p></caption><media mime-subtype="xlsx" mimetype="application" xlink:href="elife-00666-fig3-figsupp1-data1-v1.xlsx"/></supplementary-material></p></caption><graphic xlink:href="elife-00666-fig3-figsupp1-v1.tiff"/></fig></root>',
         OrderedDict([('type', 'figure'), ('assets', [OrderedDict([('type', 'image'), ('doi', u'10.7554/eLife.00666.012'), ('id', u'fig3s1'), ('label', u'Figure 3\u2014figure supplement 1'), ('title', u'Title of the figure supplement'), ('image', {'alt': '', 'uri': u'elife-00666-fig3-figsupp1-v1.tiff'}), ('sourceData', [OrderedDict([('doi', u'10.7554/eLife.00666.013'), ('id', u'SD1-data'), ('label', u'Figure 3\u2014figure supplement 1\u2014Source data 1'), ('title', u'Title of the figure supplement source data.'), ('caption', [OrderedDict([('type', 'paragraph'), ('text', u'Legend of the figure supplement source data.')])]), ('mediaType', u'application/xlsx'), ('uri', u'elife-00666-fig3-figsupp1-data1-v1.xlsx'), ('filename', u'elife-00666-fig3-figsupp1-data1-v1.xlsx')])])])])])

--- a/elifetools/tests/test_utils.py
+++ b/elifetools/tests/test_utils.py
@@ -37,6 +37,21 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(utils.strip_punctuation_space(value), expected)
 
     @unpack
+    @data(
+        (None, None, '.', None),
+        ('', None, '.', None),
+        ('Something', None, '.', 'Something'),
+        ('Short sentence', 'Another', '.', 'Short sentence. Another'),
+        ('Short sentence ', ' Another', '.', 'Short sentence. Another'),
+        ('Short sentence.', 'Another', '.', 'Short sentence. Another'),
+        ('Short sentence. ', 'Another', '.', 'Short sentence. Another'),
+        # use a comma as the glue just to check it works
+        ('Short sentence', 'Another', ',', 'Short sentence, Another'),
+        )
+    def test_join_sentences(self, value1, value2, glue, expected):
+        self.assertEqual(utils.join_sentences(value1, value2, glue), expected)
+
+    @unpack
     @data((None, None, None),
         ("1", 0xDEADBEEF, 1),
         ("1", "moo", 1),

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -53,6 +53,19 @@ def strip_punctuation_space(value):
         return [strip_punctuation(v) for v in value]
     return strip_punctuation(value)
 
+def join_sentences(string1, string2, glue='.'):
+    "concatenate two sentences together with punctuation glue"
+    if not string1 or string1 == '':
+        return string2
+    if not string2 or string2 == '':
+        return string1
+    # both are strings, continue joining them together with the glue and whitespace
+    new_string = string1.rstrip()
+    if not new_string.endswith(glue):
+        new_string += glue
+    new_string += ' ' + string2.lstrip()
+    return new_string
+
 def coerce_to_int(val, default=0xDEADBEEF):
     """Attempts to cast given value to an integer, return the original value if failed or the default if one provided."""
     try:


### PR DESCRIPTION
The ``<copyright-statement>`` was ignored if a figure had a specific attribution or licence. This change will include the copyright statement, prepended to the attribution string.

This also adds attributions for videos, previously not parsed.

Parsing attributions is spun out into a separate function.

I also created a function in ``utils.py`` called ``join_sentences()``, to smartly join two sentences together with a full stop between, except when the first portion already ends in a full stop.

In reference to JIRA tickets https://elifesciences.atlassian.net/browse/PI-598 and https://elifesciences.atlassian.net/browse/PI-599