### PR TITLE
Basic support for parsing mixed-citation and string-name data from …

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1343,6 +1343,8 @@ def refs(soup):
         set_if_value(ref, "elocation-id", node_text(first(raw_parser.elocation_id(tag))))
         if raw_parser.element_citation(tag):
             copy_attribute(first(raw_parser.element_citation(tag)).attrs, "publication-type", ref)
+        if "publication-type" not in ref and raw_parser.mixed_citations(tag):
+            copy_attribute(first(raw_parser.mixed_citations(tag)).attrs, "publication-type", ref)
 
         # authors
         person_group = raw_parser.person_group(tag)
@@ -1355,14 +1357,14 @@ def refs(soup):
                 author_type = group["person-group-type"]
 
             # Read name or collab tag in the order they are listed
-            for name_or_collab_tag in extract_nodes(group, ["name","collab"]):
+            for name_or_collab_tag in extract_nodes(group, ["name", "string-name", "collab"]):
                 author = {}
 
                 # Shared tag attribute
                 set_if_value(author, "group-type", author_type)
 
                 # name tag attributes
-                if name_or_collab_tag.name == "name":
+                if name_or_collab_tag.name in ["name", "string-name"]:
                     set_if_value(author, "surname", node_text(first(raw_parser.surname(name_or_collab_tag))))
                     set_if_value(author, "given-names", node_text(first(raw_parser.given_names(name_or_collab_tag))))
                     set_if_value(author, "suffix", node_text(first(raw_parser.suffix(name_or_collab_tag))))

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -3748,6 +3748,24 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
         ]
         ),
 
+         # example of mixed-citation with string-name, based on non-elife article
+        ('<root xmlns:xlink="http://www.w3.org/1999/xlink"><article><back><ref-list><ref><mixed-citation publication-type="book" meta="no" id="c2"><person-group person-group-type="author"><string-name><surname>Frank</surname>, <given-names>A. W.</given-names></string-name></person-group> (<year>1995</year>). <source>The wounded storyteller: Body, illness, and ethics</source>. <publisher-loc>Chicago</publisher-loc>: <publisher-name>University of Chicago Press</publisher-name>.</mixed-citation></ref></ref-list></back></article></root>',
+        [{
+            'article_doi': None,
+            'authors': [{
+                'given-names': u'A. W.',
+                'group-type': u'author',
+                'surname': u'Frank'}],
+            'position': 1,
+            'publication-type': u'book',
+            'publisher_loc': u'Chicago',
+            'publisher_name': u'University of Chicago Press',
+            'ref': u'Frank, A. W. (1995). The wounded storyteller: Body, illness, and ethics. Chicago: University of Chicago Press.',
+            'source': u'The wounded storyteller: Body, illness, and ethics',
+            'year': u'1995'
+        }]
+        ),
+
         )
     def test_refs_edge_cases(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)


### PR DESCRIPTION
…citations.

Provided an example from a non-eLife XML and a test that extracts the publication-type and the author values from the ``<string-name>`` tag.