### PR TITLE
Parse citation pub-id archive tags

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1329,11 +1329,17 @@ def refs(soup):
         if uri_tag:
             set_if_value(ref, "uri", uri_tag.get('xlink:href'))
             set_if_value(ref, "uri_text", node_contents_str(uri_tag))
+        # look for a pub-id tag if no uri yet
+        if not ref.get('uri') and raw_parser.pub_id(tag, "archive"):
+            pub_id_tag = first(raw_parser.pub_id(tag, pub_id_type="archive"))
+            set_if_value(ref, "uri", pub_id_tag.get('xlink:href'))
 
         # accession, could be in either of two tags
         set_if_value(ref, "accession", node_contents_str(first(raw_parser.object_id(tag, "art-access-id"))))
         if not ref.get('accession'):
             set_if_value(ref, "accession", node_contents_str(first(raw_parser.pub_id(tag, pub_id_type="accession"))))
+        if not ref.get('accession'):
+            set_if_value(ref, "accession", node_contents_str(first(raw_parser.pub_id(tag, pub_id_type="archive"))))
 
         if(raw_parser.year(tag)):
             set_if_value(ref, "year", node_text(raw_parser.year(tag)))

--- a/elifetools/tests/JSON/elife-00666/refs.json
+++ b/elifetools/tests/JSON/elife-00666/refs.json
@@ -1350,11 +1350,13 @@
                 "group-type": "author"
             }
         ], 
-        "publication-type": "data", 
+        "accession": "PXD001805", 
+        "uri": "http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD001805", 
         "source": "ProteomeXchange", 
         "year": "2015a", 
         "position": 34, 
         "year-iso-8601-date": "2015", 
+        "publication-type": "data", 
         "ref": "Radoshevich L Impens F Ribet D Quereda JJ Nam Tham T Nahori MA Bierne H Dussurget O Pizarro-Cerd\u00e1 J Knobeloch KP Cossart P 2015a ISG15 counteracts Listeria monocytogenes infection ProteomeXchange PXD001805", 
         "id": "bib34"
     }, 
@@ -1641,11 +1643,13 @@
                 "group-type": "author"
             }
         ], 
-        "publication-type": "data", 
+        "accession": "MA0547.1", 
+        "uri": "http://jaspar.genereg.net/cgi-bin/jaspar_db.pl", 
         "source": "JASPAR", 
         "year": "2013", 
         "position": 43, 
         "year-iso-8601-date": "2013", 
+        "publication-type": "data", 
         "ref": "Staab TA Griffen TC Corcoran C Evgrafov O Knowles JA Sieburth D 2013 SKN-1 from the JASPAR CORE database JASPAR MA0547.1", 
         "id": "bib43"
     }, 
@@ -2056,11 +2060,13 @@
                 "group-type": "author"
             }
         ], 
-        "publication-type": "data", 
+        "accession": "modENCODE_3369", 
+        "uri": "http://intermine.modencode.org/release-33/report.do?id=77000379", 
         "source": "modMine", 
         "year": "2013", 
         "position": 54, 
         "year-iso-8601-date": "2013", 
+        "publication-type": "data", 
         "ref": "Zhong M Snyder M Slightam C Kim S Murray J Waterston R Gerstein M Niu W Janette J Raha D Agarwal A Reinke V Sarov M Hyman A 2013 ChIP-Seq Identification of C. elegans TF Binding Sites modMine modENCODE_3369", 
         "id": "bib54"
     }

--- a/elifetools/tests/JSON/elife00051/title_slug.json
+++ b/elifetools/tests/JSON/elife00051/title_slug.json
@@ -1,1 +1,1 @@
-"global-divergence-in-critical-income-for-adult-and-childhood-survival-analyses-of-mortality-using-michaelismenten"
+"global-divergence-in-critical-income-for-adult-and-childhood-survival-analyses-of-mortality-using-michaelis-menten"

--- a/elifetools/tests/JSON/elife02935/authors_non_byline.json
+++ b/elifetools/tests/JSON/elife02935/authors_non_byline.json
@@ -861,7 +861,11 @@
         "group-author-key": "group-author-id2", 
         "author": "Luca Malcovati", 
         "article_doi": "10.7554/eLife.02935", 
-        "affiliations": [], 
+        "affiliations": [
+            {
+                "text": "Fondazione IRCCS Policlinico San Matteo, University of Pavia, Pavia, Italy"
+            }
+        ], 
         "given-names": "Luca", 
         "position": 50, 
         "type": "author non-byline"
@@ -871,7 +875,11 @@
         "group-author-key": "group-author-id2", 
         "author": "Sudhir Tauro", 
         "article_doi": "10.7554/eLife.02935", 
-        "affiliations": [], 
+        "affiliations": [
+            {
+                "text": "Division of Medial Sciences, University of Dundee, Dundee, UK"
+            }
+        ], 
         "given-names": "Sudhir", 
         "position": 51, 
         "type": "author non-byline"
@@ -1080,6 +1088,9 @@
                 "city": "Norwich", 
                 "institution": "University of East Anglia", 
                 "country": "UK"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "Colin", 
@@ -1101,6 +1112,9 @@
                 "country": "UK", 
                 "institution": "Royal Marsden NHS Foundation Trust", 
                 "city": "London and Sutton"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "Rosalind", 
@@ -2025,6 +2039,9 @@
                 "city": "Hinxton", 
                 "institution": "Wellcome Trust Sanger Institute", 
                 "country": "UK"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "Andrew", 
@@ -2042,6 +2059,9 @@
                 "city": "Cambridge", 
                 "institution": "University of Cambridge", 
                 "country": "UK"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "Douglas", 
@@ -2075,6 +2095,9 @@
                 "dept": "Bostwick Laboratories", 
                 "city": "London", 
                 "country": "UK"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "Christopher", 
@@ -2092,6 +2115,9 @@
                 "city": "Hinxton", 
                 "institution": "Wellcome Trust Sanger Institute", 
                 "country": "UK"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "Michael", 
@@ -2126,6 +2152,9 @@
                 "city": "Hinxton", 
                 "institution": "Wellcome Trust Sanger Institute", 
                 "country": "UK"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "Ultan", 
@@ -2171,6 +2200,9 @@
                 "city": "Cambridge", 
                 "institution": "University of Cambridge, Addenbrooke's Hospital", 
                 "country": "UK"
+            }, 
+            {
+                "text": "Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project"
             }
         ], 
         "given-names": "David", 

--- a/elifetools/tests/JSON/elife02935/contributors.json
+++ b/elifetools/tests/JSON/elife02935/contributors.json
@@ -1638,14 +1638,22 @@
         "given-names": "Luca", 
         "type": "author non-byline", 
         "group-author-key": "group-author-id2", 
-        "affiliations": []
+        "affiliations": [
+            {
+                "text": "Fondazione IRCCS Policlinico San Matteo, University of Pavia, Pavia, Italy"
+            }
+        ]
     }, 
     {
         "surname": "Tauro", 
         "given-names": "Sudhir", 
         "type": "author non-byline", 
         "group-author-key": "group-author-id2", 
-        "affiliations": []
+        "affiliations": [
+            {
+                "text": "Division of Medial Sciences, University of Dundee, Dundee, UK"
+            }
+        ]
     }, 
     {
         "surname": "Boultwood", 

--- a/elifetools/tests/JSON/elife04953/title_slug.json
+++ b/elifetools/tests/JSON/elife04953/title_slug.json
@@ -1,1 +1,1 @@
-"actin-foci-facilitate-activation-of-the-phospholipase-c-in-primary-t-lymphocytes-via-the-wasp-pathway"
+"actin-foci-facilitate-activation-of-the-phospholipase-c-g-in-primary-t-lymphocytes-via-the-wasp-pathway"

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1849,6 +1849,145 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
         ]
         ),
 
+         # example of data citation with a pub-id pub-id-type="archive", parse it as an accession number, based on 00666 kitchen sink example
+        ('''<root xmlns:xlink="http://www.w3.org/1999/xlink"><article><back><ref-list>    <ref id="bib34">
+        <element-citation publication-type="data">
+            <person-group person-group-type="author">
+                <name>
+                    <surname>Radoshevich</surname>
+                    <given-names>L</given-names>
+                </name>
+                <name>
+                    <surname>Impens</surname>
+                    <given-names>F</given-names>
+                </name>
+                <name>
+                    <surname>Ribet</surname>
+                    <given-names>D</given-names>
+                </name>
+                <name>
+                    <surname>Quereda</surname>
+                    <given-names>JJ</given-names>
+                </name>
+                <name>
+                    <surname>Nam Tham</surname>
+                    <given-names>T</given-names>
+                </name>
+                <name>
+                    <surname>Nahori</surname>
+                    <given-names>MA</given-names>
+                </name>
+                <name>
+                    <surname>Bierne</surname>
+                    <given-names>H</given-names>
+                </name>
+                <name>
+                    <surname>Dussurget</surname>
+                    <given-names>O</given-names>
+                </name>
+                <name>
+                    <surname>Pizarro-Cerdá</surname>
+                    <given-names>J</given-names>
+                </name>
+                <name>
+                    <surname>Knobeloch</surname>
+                    <given-names>KP</given-names>
+                </name>
+                <name>
+                    <surname>Cossart</surname>
+                    <given-names>P</given-names>
+                </name>
+            </person-group>
+            <year iso-8601-date="2015">2015a</year>
+            <data-title>ISG15 counteracts <italic>Listeria monocytogenes</italic>
+                infection</data-title>
+            <source>ProteomeXchange</source>
+            <pub-id pub-id-type="archive"
+                xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD001805"
+                >PXD001805</pub-id>
+        </element-citation>
+    </ref></ref-list></back></article></root>''',
+        [
+            OrderedDict([
+                ('type', u'data'),
+                ('id', u'bib34'),
+                ('date', u'2015'),
+                ('discriminator', u'a'),
+                ('authors', [
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'L Radoshevich'),
+                            ('index', u'Radoshevich, L')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'F Impens'),
+                            ('index', u'Impens, F')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'D Ribet'),
+                            ('index', u'Ribet, D')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'JJ Quereda'),
+                            ('index', u'Quereda, JJ')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'T Nam Tham'),
+                            ('index', u'Nam Tham, T')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'MA Nahori'),
+                            ('index', u'Nahori, MA')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'H Bierne'),
+                            ('index', u'Bierne, H')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'O Dussurget'),
+                            ('index', u'Dussurget, O')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'J Pizarro-Cerd\xe1'),
+                            ('index', u'Pizarro-Cerd\xe1, J')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'KP Knobeloch'),
+                            ('index', u'Knobeloch, KP')])
+                         )]),
+                    OrderedDict([
+                        ('type', 'person'),
+                        ('name', OrderedDict([
+                            ('preferred', u'P Cossart'),
+                            ('index', u'Cossart, P')])
+                        )])
+                    ]),
+                ('title', u'ISG15 counteracts <i>Listeria monocytogenes</i>\n                infection'),
+                ('source', u'ProteomeXchange'),
+                ('dataId', u'PXD001805'),
+                ('uri', u'http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD001805')
+            ])
+        ])
+
         )
     @unpack
     def test_references_json_edge_cases(self, xml_content, expected):
@@ -3797,6 +3936,136 @@ RNA-seq analysis of germline stem cell removal and loss of SKN-1 in c. elegans
             'ref': u'Frank, A. W. (1995). The wounded storyteller: Body, illness, and ethics. Chicago: University of Chicago Press.',
             'source': u'The wounded storyteller: Body, illness, and ethics',
             'year': u'1995'
+        }]
+        ),
+
+         # example of data citation with a pub-id pub-id-type="archive", parse it as an accession number, based on 00666 kitchen sink example
+        ('''<root xmlns:xlink="http://www.w3.org/1999/xlink"><article><back><ref-list>    <ref id="bib34">
+        <element-citation publication-type="data">
+            <person-group person-group-type="author">
+                <name>
+                    <surname>Radoshevich</surname>
+                    <given-names>L</given-names>
+                </name>
+                <name>
+                    <surname>Impens</surname>
+                    <given-names>F</given-names>
+                </name>
+                <name>
+                    <surname>Ribet</surname>
+                    <given-names>D</given-names>
+                </name>
+                <name>
+                    <surname>Quereda</surname>
+                    <given-names>JJ</given-names>
+                </name>
+                <name>
+                    <surname>Nam Tham</surname>
+                    <given-names>T</given-names>
+                </name>
+                <name>
+                    <surname>Nahori</surname>
+                    <given-names>MA</given-names>
+                </name>
+                <name>
+                    <surname>Bierne</surname>
+                    <given-names>H</given-names>
+                </name>
+                <name>
+                    <surname>Dussurget</surname>
+                    <given-names>O</given-names>
+                </name>
+                <name>
+                    <surname>Pizarro-Cerdá</surname>
+                    <given-names>J</given-names>
+                </name>
+                <name>
+                    <surname>Knobeloch</surname>
+                    <given-names>KP</given-names>
+                </name>
+                <name>
+                    <surname>Cossart</surname>
+                    <given-names>P</given-names>
+                </name>
+            </person-group>
+            <year iso-8601-date="2015">2015a</year>
+            <data-title>ISG15 counteracts <italic>Listeria monocytogenes</italic>
+                infection</data-title>
+            <source>ProteomeXchange</source>
+            <pub-id pub-id-type="archive"
+                xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD001805"
+                >PXD001805</pub-id>
+        </element-citation>
+    </ref></ref-list></back></article></root>''',
+        [{
+        "data-title": u"ISG15 counteracts <italic>Listeria monocytogenes</italic>\n                infection",
+        "article_doi": None,
+        "authors": [
+            {
+                "surname": u"Radoshevich",
+                "given-names": u"L",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Impens",
+                "given-names": u"F",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Ribet",
+                "given-names": u"D",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Quereda",
+                "given-names": u"JJ",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Nam Tham",
+                "given-names": u"T",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Nahori",
+                "given-names": u"MA",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Bierne",
+                "given-names": u"H",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Dussurget",
+                "given-names": u"O",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Pizarro-Cerd\u00e1",
+                "given-names": u"J",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Knobeloch",
+                "given-names": u"KP",
+                "group-type": u"author"
+            },
+            {
+                "surname": u"Cossart",
+                "given-names": u"P",
+                "group-type": u"author"
+            }
+        ],
+        "accession": "PXD001805",
+        "uri": "http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD001805",
+        "publication-type": u"data",
+        "source": u"ProteomeXchange",
+        "year": u"2015a",
+        "position": 1,
+        "year-iso-8601-date": u"2015",
+        "ref": u"Radoshevich L Impens F Ribet D Quereda JJ Nam Tham T Nahori MA Bierne H Dussurget O Pizarro-Cerd\u00e1 J Knobeloch KP Cossart P 2015a ISG15 counteracts Listeria monocytogenes infection ProteomeXchange PXD001805",
+        "id": u"bib34"
         }]
         ),
 


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-tools/issues/274.

The parser change is in ``parseJATS.py``, accompanied by some inline test data in the ``test_parse_jats.py`` file. Sorry these cases are still inline and not in file fixtures but I didn't want to hold up this parser fix to reformat them in this PR.

The JSON file fixtures updated here are to show what the parser is producing with the reference parsing change, and they also show some recent changes to parse contributor affiliation text, and some unexpected changes to slug values produced.