### PR TITLE
Datasets json support for element-citation tag

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3589,7 +3589,7 @@ def appendices_json(soup, base_url=None):
     return appendices_json
 
 
-def dataset_related_object_json(tag, html_flag=True):
+def dataset_tag_json(tag, html_flag=True):
     # Configure the XML to HTML conversion preference for shorthand use below
     convert = lambda xml_string: xml_to_html(html_flag, xml_string)
 
@@ -3648,8 +3648,8 @@ def datasets_json(soup, html_flag=True):
     datasets_json = OrderedDict()
     generated_datasets = []
     used_datasets = []
-    generated_datasets_related_object_tags = []
-    used_datasets_related_object_tags = []
+    generated_datasets_tags = []
+    used_datasets_tags = []
     availabilty_p_tags = []
     p_tags = []
     datasets_section_tag = None
@@ -3671,9 +3671,15 @@ def datasets_json(soup, html_flag=True):
             #  ones with out them are above the generated and used datasets
             if raw_parser.related_object(p_tag):
                 if dataset_type == "generated":
-                    generated_datasets_related_object_tags += raw_parser.related_object(p_tag)
+                    generated_datasets_tags += raw_parser.related_object(p_tag)
                 elif dataset_type == "used":
-                    used_datasets_related_object_tags += raw_parser.related_object(p_tag)
+                    used_datasets_tags += raw_parser.related_object(p_tag)
+            elif raw_parser.element_citation(p_tag):
+                # also look for ones with element-citation tag
+                if dataset_type == "generated":
+                    generated_datasets_tags += raw_parser.element_citation(p_tag)
+                elif dataset_type == "used":
+                    used_datasets_tags += raw_parser.element_citation(p_tag)
             else:
                 # Look for paragraphs ending in a certain term optionally with a colon at the end
                 if node_text(p_tag) and node_text(p_tag).rstrip(':').endswith("generated"):
@@ -3693,17 +3699,17 @@ def datasets_json(soup, html_flag=True):
                 datasets_json["availability"] = []
             datasets_json["availability"].append(block_content)
 
-    for related_object in generated_datasets_related_object_tags:
+    for dataset_tag in generated_datasets_tags:
         if "generated" not in datasets_json:
             datasets_json["generated"] = []
-        if dataset_related_object_json(related_object) != {}:
-            datasets_json["generated"].append(dataset_related_object_json(related_object, html_flag))
+        if dataset_tag_json(dataset_tag) != {}:
+            datasets_json["generated"].append(dataset_tag_json(dataset_tag, html_flag))
 
-    for related_object in used_datasets_related_object_tags:
+    for dataset_tag in used_datasets_tags:
         if "used" not in datasets_json:
             datasets_json["used"] = []
-        if dataset_related_object_json(related_object) != {}:
-            datasets_json["used"].append(dataset_related_object_json(related_object, html_flag))
+        if dataset_tag_json(dataset_tag) != {}:
+            datasets_json["used"].append(dataset_tag_json(dataset_tag, html_flag))
 
     return elifetools.json_rewrite.rewrite_json("datasets_json", soup, datasets_json)
 

--- a/elifetools/tests/fixtures/test_datasets_json/content_06.xml
+++ b/elifetools/tests/fixtures/test_datasets_json/content_06.xml
@@ -1,0 +1,60 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <back>
+        <sec sec-type="data-availability" id="s7">
+            <title>Data availability</title>
+            <p>All relevant data are within the paper and its Supporting Information files. The two musculoskeletal graphs used, as well as muscle community assignments, and data used to generate all figures can be found at DOI:10.5281/zenodo.1069104.</p>
+            <p>The following dataset was generated:</p>
+            <p>
+                <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+                    <person-group person-group-type="author">
+                        <name>
+                            <surname>Piwowar</surname>
+                            <given-names>HA</given-names>
+                        </name>
+                        <name>
+                            <surname>Vision</surname>
+                            <given-names>TJ</given-names>
+                        </name>
+                        <name>
+                            <surname>Whitlock</surname>
+                            <given-names>MC</given-names>
+                        </name>
+                    </person-group>
+                    <year iso-8601-date="2017">2017</year>
+                    <data-title>Data from: Data archiving is a good investmen</data-title>
+                    <source>Zenodo</source>
+                    <pub-id>245353453</pub-id>
+                    <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.5061/dryad.j1fd7">http://dx.doi.org/10.5061/dryad.j1fd7</ext-link>
+                </element-citation>
+            </p>
+            <p>The following previously published datasets were used:</p>
+            <p>
+                <element-citation publication-type="data" specific-use="references" id="dataset2">
+                    <person-group person-group-type="author">
+                        <name>
+                            <surname>Luco</surname>
+                            <given-names>RF</given-names>
+                        </name>
+                        <name>
+                            <surname>Pan</surname>
+                            <given-names>Q</given-names>
+                        </name>
+                        <name>
+                            <surname>Tominaga</surname>
+                            <given-names>K</given-names>
+                        </name>
+                        <name>
+                            <surname>Blencowe</surname>
+                            <given-names>BJ</given-names>
+                        </name>
+                    </person-group>
+                    <year iso-8601-date="2012">2012</year>
+                    <data-title>This is an amazing dataset</data-title>
+                    <source>Zenodo</source>
+                    <pub-id>243434</pub-id>
+                    <ext-link ext-link-type="uri" xlink:href="http://example.org">http://example.org</ext-link>
+                </element-citation>
+            </p>
+        </sec>
+    </back>
+</root>

--- a/elifetools/tests/fixtures/test_datasets_json/content_06_expected.py
+++ b/elifetools/tests/fixtures/test_datasets_json/content_06_expected.py
@@ -1,0 +1,84 @@
+from collections import OrderedDict
+expected = OrderedDict([
+    ('availability', [
+        OrderedDict([
+            ('type', 'paragraph'),
+            ('text', u'All relevant data are within the paper and its Supporting Information files. The two musculoskeletal graphs used, as well as muscle community assignments, and data used to generate all figures can be found at DOI:10.5281/zenodo.1069104.')
+            ])
+        ]),
+    ('generated', [
+        OrderedDict([
+            ('id', u'dataset1'),
+            ('date', u'2017'),
+            ('authors', [
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'HA Piwowar'),
+                        ('index', u'Piwowar, HA')
+                        ])
+                     )
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'TJ Vision'),
+                        ('index', u'Vision, TJ')
+                        ])
+                     )
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'MC Whitlock'),
+                        ('index', u'Whitlock, MC')
+                        ]))
+                    ])
+                ]),
+            ('title', u'Zenodo'),
+            ('uri', u'http://dx.doi.org/10.5061/dryad.j1fd7')
+            ]),
+        ]),
+    ('used', [
+        OrderedDict([
+            ('id', u'dataset2'),
+            ('date', u'2012'),
+            ('authors', [
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'RF Luco'),
+                        ('index', u'Luco, RF')
+                        ])
+                     )
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'Q Pan'),
+                        ('index', u'Pan, Q')
+                        ])
+                     )
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'K Tominaga'),
+                        ('index', u'Tominaga, K')
+                        ])
+                     )
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'BJ Blencowe'),
+                        ('index', u'Blencowe, BJ')
+                        ])
+                     )
+                    ])
+                ]),
+            ('title', u'Zenodo'),
+            ('uri', u'http://example.org')
+            ])
+        ])
+    ])

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -263,6 +263,11 @@ class TestParseJats(unittest.TestCase):
          read_fixture('test_datasets_json', 'content_05_expected.py')
          ),
 
+        # Datasets example with section sec-type data-availability and using element-citation tag
+        (read_fixture('test_datasets_json', 'content_06.xml'),
+         read_fixture('test_datasets_json', 'content_06_expected.py')
+         ),
+
         )
     def test_datasets_json(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)


### PR DESCRIPTION
In datasets_json support for element-citation tag as well as related object tags, with some variable and function renaming to match.

This is a follow-up to PR https://github.com/elifesciences/elife-tools/pull/278. A more recent sample now tested has ``<element-citation>`` tags in the datasets section instead of ``<related-object>`` tags.

This has an additional test scenario with ``<element-citation>`` tag data, and the functions are refactored a little.

A breaking change, of sorts, I renamed `dataset_related_object_json()`` to ``dataset_tag_json()`` to be more applicable to the different tags it will get. Since it was more of an internal function, no other systems would have used the old function separately, so I'm not bothering to leave an old function name stub.

Test are passing and I will merge this without code review, to get it deployed sooner.