### PR TITLE
Parse reference of type webpage

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3247,6 +3247,8 @@ def references_json(soup, html_flag=True):
             set_if_value(ref_content, "type", "conference-proceeding")
         elif ref.get("publication-type") == "clinicaltrial":
             set_if_value(ref_content, "type", "clinical-trial")
+        elif ref.get("publication-type") == "webpage":
+            set_if_value(ref_content, "type", "web")
         else:
             set_if_value(ref_content, "type", ref.get("publication-type"))
 
@@ -3260,7 +3262,7 @@ def references_json(soup, html_flag=True):
             set_if_value(ref_content, "discriminator", discriminator)
 
         # accessed
-        if ref.get("publication-type") in ["web"] and ref.get("iso-8601-date"):
+        if ref.get("publication-type") in ["web", "webpage"] and ref.get("iso-8601-date"):
             set_if_value(ref_content, "accessed", ref.get("iso-8601-date"))
             # Set the date to the year tag value if accessed is set and there is a year
             set_if_value(ref_content, "date", year_date)
@@ -3283,7 +3285,7 @@ def references_json(soup, html_flag=True):
             set_if_value(ref_content, "title", ref.get("data-title"))
             if "title" not in ref_content:
                 set_if_value(ref_content, "title", ref.get("source"))
-        elif ref.get("publication-type") in ["patent", "web"]:
+        elif ref.get("publication-type") in ["patent", "web", "webpage"]:
             set_if_value(ref_content, "title", ref.get("full_article_title"))
             if "title" not in ref_content:
                 set_if_value(ref_content, "title", ref.get("comment"))
@@ -3305,7 +3307,7 @@ def references_json(soup, html_flag=True):
             set_if_value(ref_content, "journal", ref.get("source"))
         elif ref.get("publication-type") == "periodical":
             set_if_value(ref_content, "periodical", ref.get("source"))
-        elif ref.get("publication-type") in ["web"]:
+        elif ref.get("publication-type") in ["web", "webpage"]:
             set_if_value(ref_content, "website", ref.get("source"))
         elif ref.get("publication-type") in ["patent"]:
             set_if_value(ref_content, "patentType", ref.get("source"))
@@ -3382,7 +3384,7 @@ def references_json(soup, html_flag=True):
             set_if_value(ref_content, "dataId", ref.get("accession"))
 
         # doi
-        if ref.get("publication-type") not in ["web"]:
+        if ref.get("publication-type") not in ["web", "webpage"]:
             set_if_value(ref_content, "doi", ref.get("doi"))
 
         # pmid
@@ -3393,8 +3395,12 @@ def references_json(soup, html_flag=True):
 
         # uri
         set_if_value(ref_content, "uri", ref.get("uri"))
+        # take the uri_text value if no uri yet
+        if "uri" not in ref_content:
+            set_if_value(ref_content, "uri", ref.get("uri_text"))
+        # next option is to set the uri from the doi value
         if ("uri" not in ref_content
-            and ref.get("publication-type") in ["confproc", "data", "web", "preprint"]):
+            and ref.get("publication-type") in ["confproc", "data", "web", "webpage", "preprint"]):
             if ref.get("doi"):
                 # Convert doi to uri
                 ref_content["uri"] = "https://doi.org/" + ref.get("doi")

--- a/elifetools/tests/fixtures/test_references_json/content_45.xml
+++ b/elifetools/tests/fixtures/test_references_json/content_45.xml
@@ -1,0 +1,25 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <article>
+        <back>
+            <ref-list>
+                <ref id="B33">
+                    <label>33</label>
+                    <mixed-citation publication-type="webpage">
+                        <string-name>
+                            <surname>Lotze</surname>,
+                            <given-names>W</given-names>
+                        </string-name> and
+                        <string-name>
+                            <surname>Williams</surname>,
+                            <given-names>P D</given-names>
+                        </string-name>
+                        <year>2016</year>
+                        <source>The Surge to Stabilize: Lessons for the UN from the AU&#8217;s Experience in Somalia</source>.
+                        <publisher-loc>New York</publisher-loc>: <publisher-name>International Peace Institute</publisher-name>.
+                        <uri>https://www.ipinst.org/2016/05/un-au-stabilize-somalia</uri>.
+                    </mixed-citation>
+                </ref>
+            </ref-list>
+        </back>
+    </article>
+</root>

--- a/elifetools/tests/fixtures/test_references_json/content_45_expected.py
+++ b/elifetools/tests/fixtures/test_references_json/content_45_expected.py
@@ -1,0 +1,20 @@
+from collections import OrderedDict
+expected = [
+    OrderedDict([
+        ('type', 'web'),
+        ('id', u'B33'),
+        ('date', u'2016'),
+        ('title', u'The Surge to Stabilize: Lessons for the UN from the AU\u2019s Experience in Somalia'),
+        ('website', u'The Surge to Stabilize: Lessons for the UN from the AU\u2019s Experience in Somalia'),
+        ('publisher', OrderedDict([
+            ('name', [u'International Peace Institute']),
+            ('address', OrderedDict([
+                ('formatted', [u'New York']),
+                ('components', OrderedDict([
+                    ('locality', [u'New York'])
+                    ])
+                 )])
+             )])),
+        ('uri', u'https://www.ipinst.org/2016/05/un-au-stabilize-somalia')]
+        )
+    ]

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1094,6 +1094,12 @@ class TestParseJats(unittest.TestCase):
          (read_fixture('test_references_json', 'content_44.xml'),
           read_fixture('test_references_json', 'content_44_expected.py'),
         ),
+
+         # example of ref of type webpage, based on article 10.5334/sta.606, note: does not parse author names
+         (read_fixture('test_references_json', 'content_45.xml'),
+          read_fixture('test_references_json', 'content_45_expected.py'),
+        ),
+
         )
     @unpack
     def test_references_json_edge_cases(self, xml_content, expected):


### PR DESCRIPTION
Parse references of type webpage similar to those of type web, also take the tag text value as the URI if the tag had no xlink:href value.

Citations with ``publication-type`` of ``webpage`` is commonly used, and it is similar to eLife's ``publication-type`` of ``web``.

Related to an issue when testing Crossref generation on non-eLife XML (https://github.com/elifesciences/elife-crossref-feed/issues/131), although this doesn't solve that particular problem, it is better if the parser also provides more complete JSON data from this type of XML.

The authors are not included because the author type is not provided in the example used in the tests, but the JSON output is correct in this case (I think) when the author type is ambiguous, the authors are not included.
