### PR TITLE
Parse senior editor and reviewer

### DIFF
--- a/elifetools/json_rewrite.py
+++ b/elifetools/json_rewrite.py
@@ -1128,6 +1128,19 @@ def rewrite_elife_editors_json(json_content, doi):
             if ref.get("role") == "Reviewing editor":
                 json_content[i]["role"] = "Reviewing Editor"
 
+    # Remove duplicates
+    editors_kept = []
+    for i, ref in enumerate(json_content):
+        editor_values = OrderedDict()
+        editor_values["role"] = ref.get("role")
+        if ref.get("name"):
+            editor_values["name"] = ref.get("name").get("index")
+        if editor_values in editors_kept:
+            # remove if one is already kept
+            del(json_content[i])
+        else:
+            editors_kept.append(editor_values)
+
     return json_content
 
 def rewrite_elife_title_prefix_json(json_content, doi):

--- a/elifetools/json_rewrite.py
+++ b/elifetools/json_rewrite.py
@@ -1172,6 +1172,8 @@ def person_same_name_map(json_content, role_from):
                        if person.get('role') in role_from]
     same_name_map = {}
     for i, editor in matched_editors:
+        if not editor.get("name"):
+            continue
         # compare name of each
         name = editor.get("name").get("index")
         if name not in same_name_map:

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3019,17 +3019,20 @@ def map_equal_contributions(contributors):
         equal_contribution_map[equal_contribution_key] = i+1
     return equal_contribution_map
 
+
 def editors_json(soup):
     editors_json_data = []
     contributors_data = contributors(soup, "full")
     for contributor in contributors_data:
         editor_json = None
-        if contributor["type"] == "editor":
+        if contributor["type"] in ["editor", "senior_editor"]:
             editor_json = author_person(contributor, None, None, None, None, None, None)
         if editor_json:
             editors_json_data.append(editor_json)
-    editors_json_data_rewritten = elifetools.json_rewrite.rewrite_json("editors_json", soup, editors_json_data)
+    editors_json_data_rewritten = elifetools.json_rewrite.rewrite_json(
+        "editors_json", soup, editors_json_data)
     return editors_json_data_rewritten
+
 
 def authors_json(soup):
     """authors list in article json format"""

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1160,6 +1160,12 @@ def contributors(soup, detail="brief"):
     contributors = format_authors(soup, contrib_tags, detail)
     return contributors
 
+def all_contributors(soup, detail="brief"):
+    "find all contributors not contrained to only the ones in article meta"
+    contrib_tags = raw_parser.contributors(soup)
+    contributors = format_authors(soup, contrib_tags, detail)
+    return contributors
+
 #
 # HERE BE DRAGONS
 #
@@ -3024,10 +3030,10 @@ def map_equal_contributions(contributors):
 
 def editors_json(soup):
     editors_json_data = []
-    contributors_data = contributors(soup, "full")
+    contributors_data = all_contributors(soup, "full")
     for contributor in contributors_data:
         editor_json = None
-        if contributor["type"] in ["editor", "senior_editor"]:
+        if contributor["type"] in ["editor", "senior_editor", "reviewer"]:
             editor_json = author_person(contributor, None, None, None, None, None, None)
         if editor_json:
             editors_json_data.append(editor_json)

--- a/elifetools/tests/fixtures/test_editors_json/content_05.xml
+++ b/elifetools/tests/fixtures/test_editors_json/content_05.xml
@@ -1,0 +1,79 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <article>
+        <front>
+            <journal-meta>
+                <journal-id journal-id-type="publisher-id">eLife</journal-id>
+            </journal-meta>
+            <article-meta>
+                <article-id pub-id-type="publisher-id">00666</article-id>
+                <article-id pub-id-type="doi">10.7554/eLife.00666</article-id>
+                <contrib-group content-type="section">
+                    <contrib contrib-type="senior_editor">
+                        <name>
+                            <surname>Harrison</surname>
+                            <given-names>Melissa</given-names>
+                        </name>
+                        <role>Senior Editor</role>
+                        <aff>
+                            <institution>eLife</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                    <contrib contrib-type="editor" id="author-10">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andrew</given-names>
+                        </name>
+                        <role>Reviewing Editor</role>
+                        <aff>
+                            <institution>eLife Sciences</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+            </article-meta>
+        </front>
+        <sub-article article-type="decision-letter" id="SA1">
+            <front-stub>
+                <article-id pub-id-type="doi">10.7554/eLife.00666.029</article-id>
+                <contrib-group>
+                    <contrib contrib-type="editor">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Reviewing Editor</role>
+                        <aff>
+                            <institution>eLife</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+                <contrib-group>
+                    <contrib contrib-type="reviewer">
+                        <name>
+                            <surname>Darian-Smith</surname>
+                            <given-names>Corinna</given-names>
+                        </name>
+                        <role>Reviewer</role>
+                        <aff>
+                            <institution>Stanford University</institution>
+                            <country>United States</country>
+                        </aff>
+                    </contrib>
+                    <contrib contrib-type="reviewer">
+                        <name>
+                            <surname>Smith</surname>
+                            <given-names>Alison M.</given-names>
+                        </name>
+                        <role>Reviewer</role>
+                        <aff>
+                            <institution>John Innes Centre</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+            </front-stub>
+        </sub-article>
+    </article>
+</root>

--- a/elifetools/tests/fixtures/test_editors_json/content_05.xml
+++ b/elifetools/tests/fixtures/test_editors_json/content_05.xml
@@ -22,7 +22,7 @@
                     <contrib contrib-type="editor" id="author-10">
                         <name>
                             <surname>Collings</surname>
-                            <given-names>Andrew</given-names>
+                            <given-names>Andy</given-names>
                         </name>
                         <role>Reviewing Editor</role>
                         <aff>
@@ -44,7 +44,7 @@
                         </name>
                         <role>Reviewing Editor</role>
                         <aff>
-                            <institution>eLife</institution>
+                            <institution>eLife Sciences</institution>
                             <country>United Kingdom</country>
                         </aff>
                     </contrib>

--- a/elifetools/tests/fixtures/test_editors_json/content_05_expected.py
+++ b/elifetools/tests/fixtures/test_editors_json/content_05_expected.py
@@ -22,13 +22,51 @@ expected = [
     OrderedDict([
         ('type', 'person'),
         ('name', OrderedDict([
-            ('preferred', u'Andrew Collings'),
-            ('index', u'Collings, Andrew')
+            ('preferred', u'Andy Collings'),
+            ('index', u'Collings, Andy')
             ])),
         ('role', u'Reviewing Editor'),
         ('affiliations', [
             OrderedDict([
                 ('name', [u'eLife Sciences']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United Kingdom']),
+                    ('components', OrderedDict([
+                        ('country', u'United Kingdom')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ]),
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Corinna Darian-Smith'),
+            ('index', u'Darian-Smith, Corinna')
+            ])),
+        ('role', u'Reviewer'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'Stanford University']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United States']),
+                    ('components', OrderedDict([
+                        ('country', u'United States')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ]),
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Alison M. Smith'),
+            ('index', u'Smith, Alison M.')
+            ])),
+        ('role', u'Reviewer'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'John Innes Centre']),
                 ('address', OrderedDict([
                     ('formatted', [u'United Kingdom']),
                     ('components', OrderedDict([

--- a/elifetools/tests/fixtures/test_editors_json/content_05_expected.py
+++ b/elifetools/tests/fixtures/test_editors_json/content_05_expected.py
@@ -1,0 +1,41 @@
+from collections import OrderedDict
+expected = [
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Melissa Harrison'),
+            ('index', u'Harrison, Melissa')
+            ])),
+        ('role', u'Senior Editor'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'eLife']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United Kingdom']),
+                    ('components', OrderedDict([
+                        ('country', u'United Kingdom')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ]),
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Andrew Collings'),
+            ('index', u'Collings, Andrew')
+            ])),
+        ('role', u'Reviewing Editor'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'eLife Sciences']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United Kingdom']),
+                    ('components', OrderedDict([
+                        ('country', u'United Kingdom')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ])
+    ]

--- a/elifetools/tests/fixtures/test_editors_json/content_06.xml
+++ b/elifetools/tests/fixtures/test_editors_json/content_06.xml
@@ -1,0 +1,79 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <article>
+        <front>
+            <journal-meta>
+                <journal-id journal-id-type="publisher-id">eLife</journal-id>
+            </journal-meta>
+            <article-meta>
+                <article-id pub-id-type="publisher-id">00666</article-id>
+                <article-id pub-id-type="doi">10.7554/eLife.00666</article-id>
+                <contrib-group content-type="section">
+                    <contrib contrib-type="senior_editor">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Senior Editor</role>
+                        <aff>
+                            <institution>eLife Sciences</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                    <contrib contrib-type="editor" id="author-10">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Reviewing Editor</role>
+                        <aff>
+                            <institution>eLife Sciences</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+            </article-meta>
+        </front>
+        <sub-article article-type="decision-letter" id="SA1">
+            <front-stub>
+                <article-id pub-id-type="doi">10.7554/eLife.00666.029</article-id>
+                <contrib-group>
+                    <contrib contrib-type="editor">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Reviewing Editor</role>
+                        <aff>
+                            <institution>eLife</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+                <contrib-group>
+                    <contrib contrib-type="reviewer">
+                        <name>
+                            <surname>Darian-Smith</surname>
+                            <given-names>Corinna</given-names>
+                        </name>
+                        <role>Reviewer</role>
+                        <aff>
+                            <institution>Stanford University</institution>
+                            <country>United States</country>
+                        </aff>
+                    </contrib>
+                    <contrib contrib-type="reviewer">
+                        <name>
+                            <surname>Smith</surname>
+                            <given-names>Alison M.</given-names>
+                        </name>
+                        <role>Reviewer</role>
+                        <aff>
+                            <institution>John Innes Centre</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+            </front-stub>
+        </sub-article>
+    </article>
+</root>

--- a/elifetools/tests/fixtures/test_editors_json/content_06_expected.py
+++ b/elifetools/tests/fixtures/test_editors_json/content_06_expected.py
@@ -1,0 +1,60 @@
+from collections import OrderedDict
+expected = [
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Andy Collings'),
+            ('index', u'Collings, Andy')
+            ])),
+        ('role', u'Senior and Reviewing Editor'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'eLife Sciences']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United Kingdom']),
+                    ('components', OrderedDict([
+                        ('country', u'United Kingdom')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ]),
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Corinna Darian-Smith'),
+            ('index', u'Darian-Smith, Corinna')
+            ])),
+        ('role', u'Reviewer'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'Stanford University']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United States']),
+                    ('components', OrderedDict([
+                        ('country', u'United States')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ]),
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Alison M. Smith'),
+            ('index', u'Smith, Alison M.')
+            ])),
+        ('role', u'Reviewer'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'John Innes Centre']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United Kingdom']),
+                    ('components', OrderedDict([
+                        ('country', u'United Kingdom')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ])
+    ]

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -620,6 +620,11 @@ class TestParseJats(unittest.TestCase):
          read_fixture('test_editors_json', 'content_05_expected.py')
         ),
 
+         # kitchen sink example, reviewing editor and senior editor is the same person
+        (read_fixture('test_editors_json', 'content_06.xml'),
+         read_fixture('test_editors_json', 'content_06_expected.py')
+        ),
+
         )
     def test_editors_json_edge_cases(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -615,6 +615,11 @@ class TestParseJats(unittest.TestCase):
          read_fixture('test_editors_json', 'content_04_expected.py')
         ),
 
+         # kitchen sink example, has senior editor and reviewers
+        (read_fixture('test_editors_json', 'content_05.xml'),
+         read_fixture('test_editors_json', 'content_05_expected.py')
+        ),
+
         )
     def test_editors_json_edge_cases(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)


### PR DESCRIPTION
In reference to https://github.com/elifesciences/issues/issues/54

In the editors JSON output, it will additionally include editors of type ``senior_editor`` and ``reviewer``. The editor records are also extracted from the entire article, instead of just the article meta section, to also include editors in the Decision Letter ``<sub-article>``.

For eLife articles, removes duplicate records of the same person. Additionally, if the same person is listed twice with a role of ``"Senior Editor"`` and ``"Reviewing Editor"``, then the multiple contributors are merged into one, and the role is set as ``"Senior and Reviewing Editor"``.