### PR TITLE
Fix for bug in json rewrite of editors json

### DIFF
--- a/elifetools/json_rewrite.py
+++ b/elifetools/json_rewrite.py
@@ -1155,6 +1155,7 @@ def rewrite_elife_editors_json(json_content, doi):
             if not same_id_list or len(same_id_list) <= 1:
                 # no more than one name match, nothing to replace
                 continue
+            deleted_count = 0
             for same_id in same_id_list:
                 if not role_is_set:
                     # reset the role for the first person record
@@ -1162,7 +1163,8 @@ def rewrite_elife_editors_json(json_content, doi):
                     role_is_set = True
                 else:
                     # first one is already set, remove the duplicates
-                    del json_content[same_id]
+                    del json_content[same_id-deleted_count]
+                    deleted_count += 1
 
     return json_content
 

--- a/elifetools/tests/fixtures/test_editors_json/content_07.xml
+++ b/elifetools/tests/fixtures/test_editors_json/content_07.xml
@@ -1,0 +1,77 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <article>
+        <front>
+            <journal-meta>
+                <journal-id journal-id-type="publisher-id">eLife</journal-id>
+            </journal-meta>
+            <article-meta>
+                <article-id pub-id-type="publisher-id">00666</article-id>
+                <article-id pub-id-type="doi">10.7554/eLife.00666</article-id>
+                <contrib-group content-type="section">
+                    <contrib contrib-type="editor">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Reviewing Editor</role>
+                        <aff>
+                            <institution>eLife Sciences</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                    <contrib contrib-type="senior_editor">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Senior Editor</role>
+                        <aff>
+                            <institution>eLife Sciences</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+            </article-meta>
+        </front>
+        <sub-article article-type="decision-letter" id="SA1">
+            <front-stub>
+                <article-id pub-id-type="doi">10.7554/eLife.00666.029</article-id>
+                <contrib-group>
+                    <contrib contrib-type="reviewer">
+                        <name>
+                            <surname>Darian-Smith</surname>
+                            <given-names>Corinna</given-names>
+                        </name>
+                        <role>Reviewer</role>
+                        <aff>
+                            <institution>Stanford University</institution>
+                            <country>United States</country>
+                        </aff>
+                    </contrib>
+                    <contrib contrib-type="editor">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Reviewing Editor</role>
+                        <aff>
+                            <institution>eLife Sciences</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                    <contrib contrib-type="senior_editor">
+                        <name>
+                            <surname>Collings</surname>
+                            <given-names>Andy</given-names>
+                        </name>
+                        <role>Senior Editor</role>
+                        <aff>
+                            <institution>eLife Sciences</institution>
+                            <country>United Kingdom</country>
+                        </aff>
+                    </contrib>
+                </contrib-group>
+            </front-stub>
+        </sub-article>
+    </article>
+</root>

--- a/elifetools/tests/fixtures/test_editors_json/content_07_expected.py
+++ b/elifetools/tests/fixtures/test_editors_json/content_07_expected.py
@@ -1,0 +1,41 @@
+from collections import OrderedDict
+expected = [
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Andy Collings'),
+            ('index', u'Collings, Andy')
+            ])),
+        ('role', u'Senior and Reviewing Editor'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'eLife Sciences']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United Kingdom']),
+                    ('components', OrderedDict([
+                        ('country', u'United Kingdom')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ]),
+    OrderedDict([
+        ('type', 'person'),
+        ('name', OrderedDict([
+            ('preferred', u'Corinna Darian-Smith'),
+            ('index', u'Darian-Smith, Corinna')
+            ])),
+        ('role', u'Reviewer'),
+        ('affiliations', [
+            OrderedDict([
+                ('name', [u'Stanford University']),
+                ('address', OrderedDict([
+                    ('formatted', [u'United States']),
+                    ('components', OrderedDict([
+                        ('country', u'United States')
+                        ]))
+                    ]))
+                ])
+            ]),
+        ]),
+    ]

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -625,6 +625,11 @@ class TestParseJats(unittest.TestCase):
          read_fixture('test_editors_json', 'content_06_expected.py')
         ),
 
+         #reviewing editor and senior editor is the same person in both mentions plus a reviewer
+        (read_fixture('test_editors_json', 'content_07.xml'),
+         read_fixture('test_editors_json', 'content_07_expected.py')
+        ),
+
         )
     def test_editors_json_edge_cases(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)


### PR DESCRIPTION
Fix for bug in deleting duplicate editors in json_rewrite, the index changes after each deletion.

In reference to https://github.com/elifesciences/issues/issues/4485, this should fix it. I expect automated tests will pass, and I will merge to get it deployed.