### PR TITLE
Extract the uri from dataset pub-id tags of various types.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3665,6 +3665,16 @@ def dataset_tag_json(tag, html_flag=True):
         uri_tag = first(raw_parser.ext_link(tag, "uri"))
         set_if_value(dataset_content, "uri", uri_tag.get('xlink:href'))
 
+    # uri from pub-id accession tag 
+    if "uri" not in dataset_content and raw_parser.pub_id(tag, "accession"):
+        pub_id_tag = first(raw_parser.pub_id(tag, "accession"))
+        set_if_value(dataset_content, "uri", doi_uri_to_doi(pub_id_tag.get('xlink:href')))
+
+    # uri from pub-id archive tag
+    if "uri" not in dataset_content and raw_parser.pub_id(tag, "archive"):
+        pub_id_tag = first(raw_parser.pub_id(tag, "archive"))
+        set_if_value(dataset_content, "uri", doi_uri_to_doi(pub_id_tag.get('xlink:href')))
+
     return dataset_content
 
 

--- a/elifetools/tests/fixtures/test_datasets_json/content_08.xml
+++ b/elifetools/tests/fixtures/test_datasets_json/content_08.xml
@@ -1,0 +1,87 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <back>
+        <sec sec-type="data-availability" id="s7">
+            <title>Data availability</title>
+            <p>A data availability statement will generally describe how the authors have provided the source data for their work. This can list the source data files accompanying their figures, supplementary files, and/or external dataasets. Hyperlinks can be included here, for example: <ext-link ext-link-type="uri" xlink:href="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE102999">https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE102999</ext-link></p>
+            <p>The following dataset was generated:</p>
+            <p>
+                <!--
+               UPDATE: Change to use element citation for datasets
+               -->
+               <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+                   <person-group person-group-type="author">
+                       <name>
+                           <surname>Düsterwald</surname>
+                           <given-names>KM</given-names>
+                       </name>
+                       <name>
+                           <surname>Currin</surname>
+                           <given-names>CB</given-names>
+                       </name>
+                       <name>
+                           <surname>Burman</surname>
+                           <given-names>RJ</given-names>
+                       </name>
+                       <name>
+                           <surname>Akerman</surname>
+                           <given-names>CJ</given-names>
+                       </name>
+                       <name>
+                           <surname>Kay</surname>
+                           <given-names>AR</given-names>
+                       </name>
+                       <name>
+                           <surname>Raimondo</surname>
+                           <given-names>JV</given-names>
+                       </name>
+                   </person-group>
+                   <year iso-8601-date="2018">2018</year>
+                   <data-title>Data from: Biophysical models reveal the relative importance of transporter proteins and impermeant anions in chloride homeostasis</data-title>
+                   <source>Dryad Digital Repository</source>
+                   <pub-id assigning-authority="Dryad" pub-id-type="doi">10.5061/dryad.kj1f3v4</pub-id>
+               </element-citation>
+            </p>
+            <p>The following previously published datasets were used:</p>
+            <p>
+                <element-citation publication-type="data" specific-use="references" id="dataset2">
+                    <person-group person-group-type="author">
+                        <name>
+                            <surname>Rau</surname>
+                            <given-names>CD</given-names>
+                        </name>
+                        <name>
+                            <surname>Wang</surname>
+                            <given-names>J</given-names>
+                        </name>
+                        <name>
+                            <surname>Wang</surname>
+                            <given-names>Y</given-names>
+                        </name>
+                        <name>
+                            <surname>Lusis</surname>
+                            <given-names>AJ</given-names>
+                        </name>
+                    </person-group>
+                    <year iso-8601-date="2013">2013</year>
+                    <data-title>Transcriptomes of the hybrid mouse diversity panel subjected to Isoproterenol challenge</data-title>
+                    <source>NCBI Gene Expression Omnibus</source>
+                    <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE48760">GSE48760</pub-id>
+                </element-citation>
+            </p>
+            <p>
+                <element-citation publication-type="data" specific-use="references" id="dataset3">
+                    <person-group person-group-type="author">
+                        <name>
+                            <surname>Garcia</surname>
+                            <given-names>Miguel A</given-names>
+                        </name>
+                    </person-group>
+                    <year iso-8601-date="2018">2018</year>
+                    <data-title>Shear Manuscript</data-title>
+                    <source>Open Science Framework</source>
+                    <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://osf.io/kvu5j/">kvu5j</pub-id>
+                </element-citation>
+            </p>
+        </sec>
+    </back>
+</root>

--- a/elifetools/tests/fixtures/test_datasets_json/content_08_expected.py
+++ b/elifetools/tests/fixtures/test_datasets_json/content_08_expected.py
@@ -1,0 +1,117 @@
+from collections import OrderedDict
+expected = OrderedDict([
+    ('availability', [
+        OrderedDict([
+            ('type', 'paragraph'),
+            ('text', u'A data availability statement will generally describe how the authors have provided the source data for their work. This can list the source data files accompanying their figures, supplementary files, and/or external dataasets. Hyperlinks can be included here, for example: <a href="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE102999">https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE102999</a>')
+            ])
+        ]),
+    ('generated', [
+        OrderedDict([
+            ('id', u'dataset1'),
+            ('date', u'2018'),
+            ('authors', [
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'KM D\xfcsterwald'),
+                        ('index', u'D\xfcsterwald, KM')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'CB Currin'),
+                        ('index', u'Currin, CB')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'RJ Burman'),
+                        ('index', u'Burman, RJ')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'CJ Akerman'),
+                        ('index', u'Akerman, CJ')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'AR Kay'),
+                        ('index', u'Kay, AR')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'JV Raimondo'),
+                        ('index', u'Raimondo, JV')
+                        ]))
+                    ])
+                ]),
+            ('title', u'Dryad Digital Repository'),
+            ('details', u'Data from: Biophysical models reveal the relative importance of transporter proteins and impermeant anions in chloride homeostasis'),
+            ('doi', u'10.5061/dryad.kj1f3v4')
+            ])
+        ]),
+    ('used', [
+        OrderedDict([
+            ('id', u'dataset2'),
+            ('date', u'2013'),
+            ('authors', [
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'CD Rau'),
+                        ('index', u'Rau, CD')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'J Wang'),
+                        ('index', u'Wang, J')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'Y Wang'),
+                        ('index', u'Wang, Y')
+                        ]))
+                    ]),
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'AJ Lusis'),
+                        ('index', u'Lusis, AJ')
+                        ]))
+                    ])
+                ]),
+            ('title', u'NCBI Gene Expression Omnibus'),
+            ('details', u'Transcriptomes of the hybrid mouse diversity panel subjected to Isoproterenol challenge'),
+            ('uri', u'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE48760')
+            ]),
+        OrderedDict([
+            ('id', u'dataset3'),
+            ('date', u'2018'),
+            ('authors', [
+                OrderedDict([
+                    ('type', 'person'),
+                    ('name', OrderedDict([
+                        ('preferred', u'Miguel A Garcia'),
+                        ('index', u'Garcia, Miguel A')
+                        ]))
+                    ])
+                ]),
+            ('title', u'Open Science Framework'),
+            ('details', u'Shear Manuscript'),
+            ('uri', u'https://osf.io/kvu5j/')
+            ])
+        ])
+    ])

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -273,6 +273,11 @@ class TestParseJats(unittest.TestCase):
          read_fixture('test_datasets_json', 'content_07_expected.py')
          ),
 
+        # Datasets example with new pub-id uri tagging
+        (read_fixture('test_datasets_json', 'content_08.xml'),
+         read_fixture('test_datasets_json', 'content_08_expected.py')
+         ),
+
         )
     def test_datasets_json(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-tools/issues/290

A simplistic extraction of `uri` values, if not set already, along the lines of the existing patterns of parsing logic. 

If all the automated tests pass, I will merge this and shepherd the release in other libraries to deploy it ASAP.