### PR TITLE
Look for collection year with a pub-type attribute then date-type.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -455,7 +455,9 @@ def collection_year(soup):
     Pub date of type collection will hold a year element for VOR articles
     """
     pub_date = first(raw_parser.pub_date(soup, pub_type="collection"))
-    if pub_date is None:
+    if not pub_date:
+        pub_date = first(raw_parser.pub_date(soup, date_type="collection"))
+    if not pub_date:
         return None
 
     year = None

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1803,6 +1803,34 @@ class TestParseJats(unittest.TestCase):
         self.assertEqual(self.json_expected(filename, "collection_year"),
                          parser.collection_year(self.soup(filename)))
 
+    @unpack
+    @data(
+        ('<root></root>',
+         None
+        ),
+        ('''
+        <root>
+            <pub-date pub-type="collection">
+                <year>2016</year>
+            </pub-date>
+        </root>''',
+         2016
+        ),
+        ('''
+        <root>
+            <pub-date date-type="collection">
+                <year>2016</year>
+            </pub-date>
+        </root>''',
+         2016
+        ),
+    )
+    def test_collection_year_edge_cases(self, xml_content, expected):
+        soup = parser.parse_xml(xml_content)
+        body_tag = soup.contents[0]
+        tag_content = parser.collection_year(body_tag)
+        self.assertEqual(expected, tag_content)
+
     @data("elife-kitchen-sink.xml", "elife_poa_e06828.xml")
     def test_component_doi(self, filename):
         self.assertEqual(self.json_expected(filename, "component_doi"),


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-tools/issues/293

Very simple XML tagging scenarios, I opted to just include the XML in the code rather than to create XML fixtures. I'm open to suggestion whether the XML should be pushed into fixtures though.