### PR TITLE
Pub history parsing

### DIFF
--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -205,6 +205,9 @@ def pub_history(soup):
 def event(soup):
     return extract_nodes(soup, "event")
 
+def event_desc(soup):
+    return extract_nodes(soup, "event-desc")
+
 def label(soup):
     return first(extract_nodes(soup, "label"))
 

--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -199,6 +199,12 @@ def related_object(soup):
 def object_id(soup, pub_id_type):
     return extract_nodes(soup, "object-id", attr = "pub-id-type", value = pub_id_type)
 
+def pub_history(soup):
+    return extract_nodes(soup, "pub-history")
+
+def event(soup):
+    return extract_nodes(soup, "event")
+
 def label(soup):
     return first(extract_nodes(soup, "label"))
 

--- a/elifetools/tests/fixtures/test_pub_history/content_01.xml
+++ b/elifetools/tests/fixtures/test_pub_history/content_01.xml
@@ -1,0 +1,13 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <pub-history>
+        <event event-type="preprint-publication">
+            <event-desc>This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</ext-link>
+            </event-desc>
+            <date iso-8601-date="2016-03-01">
+                <day>24</day>
+                <month>03</month>
+                <year>2017</year>
+            </date>
+        </event>
+    </pub-history>
+</root>

--- a/elifetools/tests/fixtures/test_pub_history/content_01.xml
+++ b/elifetools/tests/fixtures/test_pub_history/content_01.xml
@@ -3,7 +3,7 @@
         <event event-type="preprint-publication">
             <event-desc>This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</ext-link>
             </event-desc>
-            <date iso-8601-date="2016-03-01">
+            <date iso-8601-date="2017-03-24">
                 <day>24</day>
                 <month>03</month>
                 <year>2017</year>

--- a/elifetools/tests/fixtures/test_pub_history/content_01.xml
+++ b/elifetools/tests/fixtures/test_pub_history/content_01.xml
@@ -1,7 +1,7 @@
 <root xmlns:xlink="http://www.w3.org/1999/xlink">
     <pub-history>
         <event event-type="preprint-publication">
-            <event-desc>This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</ext-link>
+            <event-desc>This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on bioRxiv</ext-link>
             </event-desc>
             <date iso-8601-date="2017-03-24">
                 <day>24</day>

--- a/elifetools/tests/fixtures/test_pub_history/content_01_expected.py
+++ b/elifetools/tests/fixtures/test_pub_history/content_01_expected.py
@@ -5,10 +5,10 @@ from elifetools.utils import date_struct
 expected = [
     OrderedDict([
         ('event_type', 'preprint-publication'),
-        ('event_desc', 'This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</ext-link>'),
-        ('event_desc_html', 'This article was originally published as a <a href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</a>'),
+        ('event_desc', 'This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on bioRxiv</ext-link>'),
+        ('event_desc_html', 'This article was originally published as a <a href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on bioRxiv</a>'),
         ('uri', 'https://www.biorxiv.org/content/early/2017/03/24/118356'),
-        ('uri_text', 'preprint on Biorxiv'),
+        ('uri_text', 'preprint on bioRxiv'),
         ('day', '24'),
         ('month', '03'),
         ('year', '2017'),

--- a/elifetools/tests/fixtures/test_pub_history/content_01_expected.py
+++ b/elifetools/tests/fixtures/test_pub_history/content_01_expected.py
@@ -12,7 +12,7 @@ expected = [
         ('day', '24'),
         ('month', '03'),
         ('year', '2017'),
-        (u'date', date_struct(2017, 3, 24)),
+        ('date', date_struct(2017, 3, 24)),
         ('iso-8601-date', '2017-03-24')
         ])
     ]

--- a/elifetools/tests/fixtures/test_pub_history/content_01_expected.py
+++ b/elifetools/tests/fixtures/test_pub_history/content_01_expected.py
@@ -1,0 +1,18 @@
+from collections import OrderedDict
+from elifetools.utils import date_struct
+
+
+expected = [
+    OrderedDict([
+        ('event_type', 'preprint-publication'),
+        ('event_desc', 'This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</ext-link>'),
+        ('event_desc_html', 'This article was originally published as a <a href="https://www.biorxiv.org/content/early/2017/03/24/118356">preprint on Biorxiv</a>'),
+        ('uri', 'https://www.biorxiv.org/content/early/2017/03/24/118356'),
+        ('uri_text', 'preprint on Biorxiv'),
+        ('day', '24'),
+        ('month', '03'),
+        ('year', '2017'),
+        (u'date', date_struct(2017, 3, 24)),
+        ('iso-8601-date', '2017-03-24')
+        ])
+    ]

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -2427,7 +2427,7 @@ class TestParseJats(unittest.TestCase):
         ('',
          []
         ),
-        (read_fixture('test_pub_history','content_01.xml'),
+        (read_fixture('test_pub_history', 'content_01.xml'),
          read_fixture('test_pub_history', 'content_01_expected.py')
         ),
     )

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -2422,6 +2422,19 @@ class TestParseJats(unittest.TestCase):
         tag_content = parser.version_history(soup)
         self.assertEqual(expected, tag_content)
 
+    @unpack
+    @data(
+        ('',
+         []
+        ),
+        (read_fixture('test_pub_history','content_01.xml'),
+         read_fixture('test_pub_history', 'content_01_expected.py')
+        ),
+    )
+    def test_pub_history(self, xml_content, expected):
+        soup = parser.parse_xml(xml_content)
+        tag_content = parser.pub_history(soup)
+        self.assertEqual(expected, tag_content)
 
 
 if __name__ == '__main__':

--- a/elifetools/tests/test_raw_parser.py
+++ b/elifetools/tests/test_raw_parser.py
@@ -345,6 +345,16 @@ class TestJatsParser(unittest.TestCase):
         soup = parser.parse_xml(xml_content)
         self.assertEqual(len(raw_parser.event(soup)), expected_len)
 
+    @unpack
+    @data(
+        (read_fixture("test_pub_history", "content_01.xml"), 1),
+    )
+    def test_event_desc(self, xml_content, expected_len):
+        soup = parser.parse_xml(xml_content)
+        self.assertEqual(len(raw_parser.event_desc(soup)), expected_len)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/elifetools/tests/test_raw_parser.py
+++ b/elifetools/tests/test_raw_parser.py
@@ -6,7 +6,8 @@ import bs4
 from ddt import ddt, data, unpack
 from elifetools import parseJATS as parser
 from elifetools import rawJATS as raw_parser
-from elifetools.file_utils import sample_xml
+from elifetools.file_utils import sample_xml, read_fixture
+
 
 @ddt
 class TestJatsParser(unittest.TestCase):
@@ -327,6 +328,23 @@ class TestJatsParser(unittest.TestCase):
     def test_mixed_citations(self):
         self.soup = parser.parse_document(sample_xml('elife-kitchen-sink.xml'))
         self.assertEqual(1, len(raw_parser.mixed_citations(self.soup)))
+
+    @unpack
+    @data(
+        (read_fixture("test_pub_history", "content_01.xml"), 1),
+    )
+    def test_pub_history(self, xml_content, expected_len):
+        soup = parser.parse_xml(xml_content)
+        self.assertEqual(len(raw_parser.pub_history(soup)), expected_len)
+
+    @unpack
+    @data(
+        (read_fixture("test_pub_history", "content_01.xml"), 1),
+    )
+    def test_raw_event(self, xml_content, expected_len):
+        soup = parser.parse_xml(xml_content)
+        self.assertEqual(len(raw_parser.event(soup)), expected_len)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In reference to issue https://github.com/elifesciences/issues/issues/4342 for preprint data.

Raw parser extracts additional types of basic tags.

`parseJATS.pub_history()` returns a list of `OrderedDict()`, one item for each `<event>` tag.

I followed the style of how we extract existing tags regarding the date values and `uri`. The raw content of the `<event-desc>` tag is available (which is useful in other libraries).

I threw in `event_desc_html` because the parser is good at converting to HTML. It didn't seem to be worth creating another function for that, and maybe the HTML is useful elsewhere too.