### PR TITLE
Datasets assigningAuthority and more dataId

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3693,6 +3693,7 @@ def dataset_tag_json(tag, html_flag=True):
         if "doi" not in dataset_content:
             # use the tag value if xlink:href attribute is not present
             set_if_value(dataset_content, "doi", doi_uri_to_doi(node_contents_str(doi_tag)))
+        set_if_value(dataset_content, "assigningAuthority", doi_tag.get('assigning-authority'))
 
     # uri
     if raw_parser.ext_link(tag, "uri"):
@@ -3708,6 +3709,7 @@ def dataset_tag_json(tag, html_flag=True):
         # set dataId if missing and the pub-id is an accession
         if "dataId" not in dataset_content and pub_id_tag.get("pub-id-type") == "accession":
             set_if_value(dataset_content, "dataId", convert(node_contents_str(pub_id_tag)))
+        set_if_value(dataset_content, "assigningAuthority", pub_id_tag.get('assigning-authority'))
 
     return dataset_content
 

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3699,15 +3699,15 @@ def dataset_tag_json(tag, html_flag=True):
         uri_tag = first(raw_parser.ext_link(tag, "uri"))
         set_if_value(dataset_content, "uri", uri_tag.get('xlink:href'))
 
-    # uri from pub-id accession tag 
-    if "uri" not in dataset_content and raw_parser.pub_id(tag, "accession"):
-        pub_id_tag = first(raw_parser.pub_id(tag, "accession"))
-        set_if_value(dataset_content, "uri", doi_uri_to_doi(pub_id_tag.get('xlink:href')))
-
-    # uri from pub-id archive tag
-    if "uri" not in dataset_content and raw_parser.pub_id(tag, "archive"):
-        pub_id_tag = first(raw_parser.pub_id(tag, "archive"))
-        set_if_value(dataset_content, "uri", doi_uri_to_doi(pub_id_tag.get('xlink:href')))
+    # uri from pub-id tag 
+    if "uri" not in dataset_content and raw_parser.pub_id(tag):
+        pub_id_tag = first(raw_parser.pub_id(tag))
+        # set uri if it is not a doi tag
+        if pub_id_tag.get("pub-id-type") != "doi":
+            set_if_value(dataset_content, "uri", pub_id_tag.get("xlink:href"))
+        # set dataId if missing and the pub-id is an accession
+        if "dataId" not in dataset_content and pub_id_tag.get("pub-id-type") == "accession":
+            set_if_value(dataset_content, "dataId", convert(node_contents_str(pub_id_tag)))
 
     return dataset_content
 

--- a/elifetools/tests/fixtures/test_datasets_json/content_02_expected.py
+++ b/elifetools/tests/fixtures/test_datasets_json/content_02_expected.py
@@ -59,7 +59,8 @@ expected = OrderedDict([
                 ]),
             ('title', u'Dryad Digital Repository'),
             ('details', u'Data from: Genome-wide errant targeting by Hairy'),
-            ('doi', u'10.5061/dryad.cv323')
+            ('doi', u'10.5061/dryad.cv323'),
+            ('assigningAuthority', u'Dryad Digital Repository')
             ])
         ])
     ])

--- a/elifetools/tests/fixtures/test_datasets_json/content_04_expected.py
+++ b/elifetools/tests/fixtures/test_datasets_json/content_04_expected.py
@@ -65,7 +65,8 @@ expected = OrderedDict([
                 ]),
             ('title', u'Dryad Digital Repository'),
             ('details', u'Data from: Genome-wide errant targeting by Hairy'),
-            ('doi', u'10.5061/dryad.cv323')
+            ('doi', u'10.5061/dryad.cv323'),
+            ('assigningAuthority', u'Dryad Digital Repository')
             ])
         ])
     ])

--- a/elifetools/tests/fixtures/test_datasets_json/content_06_expected.py
+++ b/elifetools/tests/fixtures/test_datasets_json/content_06_expected.py
@@ -37,7 +37,8 @@ expected = OrderedDict([
                 ]),
             ('title', u'Dryad'),
             ('details', u'Data from: Data archiving is a good investmen'),
-            ('doi', u'10.5061/dryad.j1fd7')
+            ('doi', u'10.5061/dryad.j1fd7'),
+            ('assigningAuthority', u'dryad')
             ]),
         ]),
     ('used', [
@@ -80,7 +81,8 @@ expected = OrderedDict([
                 ]),
             ('title', u'Zenodo'),
             ('details', u'This is an amazing dataset'),
-            ('doi', u'10.11144/Javeriana.cl20-39.bdfp')
+            ('doi', u'10.11144/Javeriana.cl20-39.bdfp'),
+            ('assigningAuthority', u'zenodo')
             ])
         ])
     ])

--- a/elifetools/tests/fixtures/test_datasets_json/content_08_expected.py
+++ b/elifetools/tests/fixtures/test_datasets_json/content_08_expected.py
@@ -95,7 +95,8 @@ expected = OrderedDict([
                 ]),
             ('title', u'NCBI Gene Expression Omnibus'),
             ('details', u'Transcriptomes of the hybrid mouse diversity panel subjected to Isoproterenol challenge'),
-            ('uri', u'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE48760')
+            ('uri', u'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE48760'),
+            ('dataId', u'GSE48760')
             ]),
         OrderedDict([
             ('id', u'dataset3'),

--- a/elifetools/tests/fixtures/test_datasets_json/content_08_expected.py
+++ b/elifetools/tests/fixtures/test_datasets_json/content_08_expected.py
@@ -56,7 +56,8 @@ expected = OrderedDict([
                 ]),
             ('title', u'Dryad Digital Repository'),
             ('details', u'Data from: Biophysical models reveal the relative importance of transporter proteins and impermeant anions in chloride homeostasis'),
-            ('doi', u'10.5061/dryad.kj1f3v4')
+            ('doi', u'10.5061/dryad.kj1f3v4'),
+            ('assigningAuthority', u'Dryad')
             ])
         ]),
     ('used', [
@@ -96,7 +97,8 @@ expected = OrderedDict([
             ('title', u'NCBI Gene Expression Omnibus'),
             ('details', u'Transcriptomes of the hybrid mouse diversity panel subjected to Isoproterenol challenge'),
             ('uri', u'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE48760'),
-            ('dataId', u'GSE48760')
+            ('dataId', u'GSE48760'),
+            ('assigningAuthority', u'NCBI')
             ]),
         OrderedDict([
             ('id', u'dataset3'),
@@ -112,7 +114,8 @@ expected = OrderedDict([
                 ]),
             ('title', u'Open Science Framework'),
             ('details', u'Shear Manuscript'),
-            ('uri', u'https://osf.io/kvu5j/')
+            ('uri', u'https://osf.io/kvu5j/'),
+            ('assigningAuthority', u'other')
             ])
         ])
     ])


### PR DESCRIPTION
As part of ticket https://github.com/elifesciences/elife-pubmed-feed/issues/61, here is the parser extracting more data from the XML.

The datasets JSON output will now include an additional value, `assigningAuthority`, if it finds the data in the XML file. It will, I think, flow unaltered to Lax and the API even though there is no definition for the value, and it will hopefully be silent and ignored there, unless it is wanted later.

The `dataId` value is also expanded to take it from the text of the `<pub-id>` tag, if it is `pub-id-type="accession"`.

I need the `assigningAuthority` value in order to send it to PubMed, and I can continue the effort once this is merged.