### PR TITLE
Refactor and remove duplicate_tag()

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1068,9 +1068,8 @@ def format_contributor(contrib_tag, soup, detail="brief", contrib_type=None,
         collab_tag = first(raw_parser.collab(contrib_tag))
         if collab_tag:
             # Clean up if there are tags inside the collab tag
-            tag_copy = duplicate_tag(collab_tag)
-            tag_copy = remove_tag_from_tag(tag_copy, 'contrib-group')
-            contributor['collab'] = node_contents_str(tag_copy).rstrip()
+            collab_tag = remove_tag_from_tag(collab_tag, 'contrib-group')
+            contributor['collab'] = node_contents_str(collab_tag).rstrip()
 
     # Check if it is not a group author
     if not is_author_group_author(contrib_tag):

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1063,7 +1063,7 @@ def format_contributor(contrib_tag, soup, detail="brief", contrib_type=None,
         if collab_tag:
             # Clean up if there are tags inside the collab tag
             tag_copy = copy.copy(collab_tag)
-            collab_tag = remove_tag_from_tag(tag_copy, 'contrib-group')
+            tag_copy = remove_tag_from_tag(tag_copy, 'contrib-group')
             contributor['collab'] = node_contents_str(tag_copy).rstrip()
 
     # Check if it is not a group author

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -18,13 +18,6 @@ def parse_document(filelocation):
     with open(filelocation, 'rb') as fp:
         return parse_xml(fp)
 
-def duplicate_tag(tag):
-    # Make a completely new copy of a tag by parsing its contents again
-    tag_xml = u'<article xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">' + unicode_value(tag) + u'</article>'
-    soup_copy = parse_xml(tag_xml)
-    tag_copy = first(extract_nodes(soup_copy, tag.name))
-    return tag_copy
-
 def title(soup):
     return node_text(raw_parser.article_title(soup))
 

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2386,11 +2386,10 @@ def body_block_content(tag, html_flag=True, base_url=None):
 
         # Remove unwanted nested tags
         unwanted_tag_names = body_block_nodenames()
-        tag_copy = duplicate_tag(tag)
-        tag_copy = remove_tag_from_tag(tag_copy, unwanted_tag_names)
+        tag = remove_tag_from_tag(tag, unwanted_tag_names)
 
-        if node_contents_str(tag_copy):
-            tag_content["text"] = convert(clean_whitespace(node_contents_str(tag_copy)))
+        if node_contents_str(tag):
+            tag_content["text"] = convert(clean_whitespace(node_contents_str(tag)))
 
     elif tag.name == "disp-quote":
         if tag.get("content-type") and tag.get("content-type") == "editor-comment":

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import copy
 
 from bs4 import BeautifulSoup
 from slugify import slugify
@@ -1068,8 +1069,9 @@ def format_contributor(contrib_tag, soup, detail="brief", contrib_type=None,
         collab_tag = first(raw_parser.collab(contrib_tag))
         if collab_tag:
             # Clean up if there are tags inside the collab tag
-            collab_tag = remove_tag_from_tag(collab_tag, 'contrib-group')
-            contributor['collab'] = node_contents_str(collab_tag).rstrip()
+            tag_copy = copy.copy(collab_tag)
+            collab_tag = remove_tag_from_tag(tag_copy, 'contrib-group')
+            contributor['collab'] = node_contents_str(tag_copy).rstrip()
 
     # Check if it is not a group author
     if not is_author_group_author(contrib_tag):

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -1301,10 +1301,9 @@ def format_aff(aff_tag):
     # If all values are none then extract as text
     if not values:
         # extract the text ignoring the label tag
-        aff_tag_copy = duplicate_tag(aff_tag)
-        aff_tag_copy = remove_tag_from_tag(aff_tag, 'label')
+        aff_tag = remove_tag_from_tag(aff_tag, 'label')
         values = {
-            'text': node_text(aff_tag_copy).strip()
+            'text': node_text(aff_tag).strip()
         }
 
     if 'id' in aff_tag.attrs:

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1612,16 +1612,6 @@ class TestParseJats(unittest.TestCase):
     def test_history_date(self, filename, date_type, expected):
         self.assertEqual(expected, parser.history_date(self.soup(filename), date_type))
 
-    @unpack
-    @data(("<p></p>", "paragraph", "<p/>"),
-        (u"<p>§ <italic>*</italic></p>", "paragraph", u"<p>§ <italic>*</italic></p>"),)
-    def test_duplicate_tag(self, xml, parser_function, expected_xml):
-        # To test, first parse the XML into a tag, then duplicate it, then check the contents
-        soup = parser.parse_xml(xml)
-        tags = getattr(raw_parser, parser_function)(soup)
-        tag_copy = parser.duplicate_tag(tags[0])
-        self.assertEqual(expected_xml, unicode_value(tag_copy))
-
     """
     Functions that require more than one argument to test against json output
     """


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-tools/issues/299
In reference to PR https://github.com/elifesciences/elife-tools/pull/298

I removed the uses of `duplicate_tag()` where used to see if the tests still pass. One place still required a duplicate tag before the tag is modified and still produce the same output expected in the test scenarios. Using `copy.copy()` for duplicating the tag now.

This allows all the tests to pass for me in Python 3 (on mac) using the upgraded `Beautifulsoup` and `lxml` dependencies.
