### PR TITLE
Update requirements and install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4==4.7.1
 lxml==4.3.0
 python-slugify==1.2.4
+six==1.12.0
 coverage==3.7.1
 ddt==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 beautifulsoup4==4.7.1
 lxml==4.3.0
 python-slugify==1.2.4
-unittest-xml-reporting==1.12.0
 coverage==3.7.1
 ddt==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     install_requires=[
         "beautifulsoup4",
         "lxml",
-        "python-slugify"
+        "python-slugify",
+        "six"
     ],
     url='https://github.com/elifesciences/elife-tools',
     maintainer='eLife Sciences Publications Ltd.',

--- a/setup.py
+++ b/setup.py
@@ -3,27 +3,28 @@ from setuptools import setup
 import elifetools
 
 with open('README.rst') as fp:
-    readme = fp.read()
+    README = fp.read()
 
-setup(name='elifetools',
-      version=elifetools.__version__,
-      description='Tools for using article data in Python.',
-      long_description=readme,
-      packages=['elifetools'],
-      license = 'MIT',
-      install_requires=[
+setup(
+    name='elifetools',
+    version=elifetools.__version__,
+    description='Tools for using article data in Python.',
+    long_description=README,
+    packages=['elifetools'],
+    license='MIT',
+    install_requires=[
         "beautifulsoup4",
         "lxml",
         "python-slugify"
-      ],
-      url='https://github.com/elifesciences/elife-tools',
-      maintainer='eLife Sciences Publications Ltd.',
-      maintainer_email='py@elifesciences.org',
-      classifiers=[
-          "Development Status :: 3 - Alpha",
-          "Intended Audience :: Developers",
-          "License :: OSI Approved :: MIT License",
-          "Programming Language :: Python :: 2",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.5",
-      ])
+    ],
+    url='https://github.com/elifesciences/elife-tools',
+    maintainer='eLife Sciences Publications Ltd.',
+    maintainer_email='py@elifesciences.org',
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+    ])

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,17 @@ import elifetools
 with open('README.rst') as fp:
     readme = fp.read()
 
-with open('requirements.txt') as f:
-    install_requires = f.read().splitlines()
-
 setup(name='elifetools',
       version=elifetools.__version__,
       description='Tools for using article data in Python.',
       long_description=readme,
       packages=['elifetools'],
       license = 'MIT',
-      install_requires=install_requires,
+      install_requires=[
+        "beautifulsoup4",
+        "lxml",
+        "python-slugify"
+      ],
       url='https://github.com/elifesciences/elife-tools',
       maintainer='eLife Sciences Publications Ltd.',
       maintainer_email='py@elifesciences.org',


### PR DESCRIPTION
Reviewing requirements, I wanted to move away from parsing the `requirements.txt` file to determine the `setup.py` `install_requires`, because a library may not need all of the stated requirements to run, such as `coverage` and `ddt`, for example.

The rest of the changes in `setup.py` are due to linting.