### PR TITLE
Include email in JSON output for all authors.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2852,7 +2852,7 @@ def author_email_addresses(author, correspondence):
                 email_addresses.append(affiliation["email"])
 
     # Also look at the author attributes
-    if author.get("corresp") and author.get("email"):
+    if author.get("email"):
         email_addresses = author["email"]
 
     if email_addresses != []:


### PR DESCRIPTION
Something discovered in issue https://github.com/elifesciences/issues/issues/4837, the `emailAddresses` in the JSON output for authors that are not corresponding authors are not included in the JSON output.

I think this will have no noticeable impact for eLife articles, since non-corresponding author XML doesn't include email addresses.