### PR TITLE
Add doi to pub_history event data parsed

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -160,6 +160,18 @@ def related_object_ids(soup):
     return dict(map(format_related_object, tags))
 
 
+def article_id_list(soup):
+    """return a list of article-id data"""
+    id_list = []
+    for article_id_tag in raw_parser.article_id(soup):
+        id_details = OrderedDict()
+        set_if_value(id_details, "type", article_id_tag.get("pub-id-type"))
+        set_if_value(id_details, "value", article_id_tag.text)
+        set_if_value(id_details, "assigning-authority", article_id_tag.get("assigning-authority"))
+        id_list.append(id_details)
+    return id_list
+
+
 def pub_history(soup):
     events = []
     pub_history = first(raw_parser.pub_history(soup))
@@ -178,9 +190,8 @@ def pub_history(soup):
             if uri_tag:
                 set_if_value(event, "uri", uri_tag.get('xlink:href'))
                 set_if_value(event, "uri_text", node_contents_str(uri_tag))
-            article_id_tag = first(raw_parser.article_id(event_tag, "doi"))
-            if article_id_tag:
-                event['doi'] = article_id_tag.text
+            if article_id_list(event_tag):
+                event['id_list'] = article_id_list(event_tag)
             date_tag = first(raw_parser.date(event_tag))
             if date_tag:
                 (day, month, year) = ymd(date_tag)

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -178,6 +178,9 @@ def pub_history(soup):
             if uri_tag:
                 set_if_value(event, "uri", uri_tag.get('xlink:href'))
                 set_if_value(event, "uri_text", node_contents_str(uri_tag))
+            article_id_tag = first(raw_parser.article_id(event_tag, "doi"))
+            if article_id_tag:
+                event['doi'] = article_id_tag.text
             date_tag = first(raw_parser.date(event_tag))
             if date_tag:
                 (day, month, year) = ymd(date_tag)

--- a/elifetools/rawJATS.py
+++ b/elifetools/rawJATS.py
@@ -20,8 +20,11 @@ def abstract(soup, abstract_type=None):
     else:
         return extract_nodes(soup, "abstract")
 
-def article_id(soup, pub_id_type):
-    return extract_nodes(soup, "article-id", attr = "pub-id-type", value = pub_id_type)
+def article_id(soup, pub_id_type=None):
+    if pub_id_type:
+        return extract_nodes(soup, "article-id", attr="pub-id-type", value=pub_id_type)
+    else:
+        return extract_nodes(soup, "article-id")
 
 def doi(soup):
     doi_tags = article_id(soup, pub_id_type = "doi")

--- a/elifetools/tests/fixtures/test_pub_history/content_02.xml
+++ b/elifetools/tests/fixtures/test_pub_history/content_02.xml
@@ -1,0 +1,14 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <pub-history>
+        <event event-type="preprint-publication">
+            <event-desc>This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1101/118356">preprint</ext-link> on bioRxiv.
+            </event-desc>
+            <article-id pub-id-type="doi" assigning-authority="crossref">10.1101/118356</article-id>
+            <date iso-8601-date="2017-03-24">
+                <day>24</day>
+                <month>03</month>
+                <year>2017</year>
+            </date>
+        </event>
+    </pub-history>
+</root>

--- a/elifetools/tests/fixtures/test_pub_history/content_02_expected.py
+++ b/elifetools/tests/fixtures/test_pub_history/content_02_expected.py
@@ -9,7 +9,13 @@ expected = [
         ('event_desc_html', 'This article was originally published as a <a href="https://doi.org/10.1101/118356">preprint</a> on bioRxiv.'),
         ('uri', 'https://doi.org/10.1101/118356'),
         ('uri_text', 'preprint'),
-        ('doi', '10.1101/118356'),
+        ('id_list', [
+            OrderedDict([
+                ('type', 'doi'),
+                ('value', '10.1101/118356'),
+                ('assigning-authority', 'crossref')
+                ])
+        ]),
         ('day', '24'),
         ('month', '03'),
         ('year', '2017'),

--- a/elifetools/tests/fixtures/test_pub_history/content_02_expected.py
+++ b/elifetools/tests/fixtures/test_pub_history/content_02_expected.py
@@ -1,0 +1,19 @@
+from collections import OrderedDict
+from elifetools.utils import date_struct
+
+
+expected = [
+    OrderedDict([
+        ('event_type', 'preprint-publication'),
+        ('event_desc', 'This article was originally published as a <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1101/118356">preprint</ext-link> on bioRxiv.'),
+        ('event_desc_html', 'This article was originally published as a <a href="https://doi.org/10.1101/118356">preprint</a> on bioRxiv.'),
+        ('uri', 'https://doi.org/10.1101/118356'),
+        ('uri_text', 'preprint'),
+        ('doi', '10.1101/118356'),
+        ('day', '24'),
+        ('month', '03'),
+        ('year', '2017'),
+        ('date', date_struct(2017, 3, 24)),
+        ('iso-8601-date', '2017-03-24')
+        ])
+    ]

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -2420,6 +2420,9 @@ class TestParseJats(unittest.TestCase):
         (read_fixture('test_pub_history', 'content_01.xml'),
          read_fixture('test_pub_history', 'content_01_expected.py')
         ),
+        (read_fixture('test_pub_history', 'content_02.xml'),
+         read_fixture('test_pub_history', 'content_02_expected.py')
+        ),
     )
     def test_pub_history(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)


### PR DESCRIPTION
Re: issue https://github.com/elifesciences/issues/issues/4284, there's a new XML sample that includes a `doi`. I added it to the `pub_history()` output and added a new XML sample for the latest XML.

If you might want to review @lsh-0 - I think you're the next possible user of this data.