### PR TITLE
Comment tag fix

### DIFF
--- a/elifetools/tests/fixtures/test_body_block_content/content_41.xml
+++ b/elifetools/tests/fixtures/test_body_block_content/content_41.xml
@@ -1,0 +1,3 @@
+<root>
+    <p>Text <italic>more</italic> text <!-- and a comment --></p>
+</root>

--- a/elifetools/tests/fixtures/test_body_block_content/content_41_expected.py
+++ b/elifetools/tests/fixtures/test_body_block_content/content_41_expected.py
@@ -1,0 +1,5 @@
+from collections import OrderedDict
+expected = OrderedDict([
+    ('type', 'paragraph'),
+    ('text', 'Text <i>more</i> text ')
+    ])

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1346,6 +1346,11 @@ class TestParseJats(unittest.TestCase):
           read_fixture('test_body_block_content', 'content_40_expected.py'),
          ),
 
+        # test for stripping out comment tag content when it is inside a paragraph tag
+         (read_fixture('test_body_block_content', 'content_41.xml'),
+          read_fixture('test_body_block_content', 'content_41_expected.py'),
+         ),
+
         )
     def test_body_block_content(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -275,7 +275,7 @@ def node_contents_str(tag):
     tag_string = ''
     for child_tag in tag.children:
         if isinstance(child_tag, Comment):
-            # BeautifulSoup does not preserve content tags, add them back
+            # BeautifulSoup does not preserve comment tags, add them back
             tag_string += '<!--%s-->' % unicode_value(child_tag)
         else:
             tag_string += unicode_value(child_tag)

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -4,6 +4,7 @@ import re
 from collections import OrderedDict
 from six import iteritems
 from slugify import slugify
+from bs4 import Comment
 
 
 def unicode_value(value):
@@ -271,7 +272,15 @@ def node_contents_str(tag):
     """
     if tag is None:
         return None
-    return "".join(list(map(unicode_value, tag.children))) or None
+    tag_string = ''
+    for child_tag in tag.children:
+        if isinstance(child_tag, Comment):
+            # BeautifulSoup does not preserve content tags, add them back
+            if unicode_value(child_tag):
+                tag_string += '<!--%s-->' % unicode_value(child_tag)
+        else:
+            tag_string += unicode_value(child_tag)
+    return tag_string
 
 def first_parent(tag, nodename):
     """

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -276,8 +276,7 @@ def node_contents_str(tag):
     for child_tag in tag.children:
         if isinstance(child_tag, Comment):
             # BeautifulSoup does not preserve content tags, add them back
-            if unicode_value(child_tag):
-                tag_string += '<!--%s-->' % unicode_value(child_tag)
+            tag_string += '<!--%s-->' % unicode_value(child_tag)
         else:
             tag_string += unicode_value(child_tag)
     return tag_string


### PR DESCRIPTION
When I tested converting a new XML format to JSON output, in issue https://github.com/elifesciences/elife-crossref-feed/issues/123, and I compared the input and output very carefully, I noticed some text in the output that was originally inside XML comment tags. 

The convention in this project was when converting XML to HTML, the comment tags and the content inside them was to be stripped out.

That seemed to work in the test case examples for `table-wrap`. The content that was not getting stripped out was in a `<p>` tag.

Following all the parser calls, I tracked down what I think is the issue. When a BeautifulSoup tag is converted to a string (which preserves inline tagging, and is then further processed), if the tag is a `Comment` tag then it gives you the text but removes the comment tags. 

The intention of the `node_contents_str()` function in this project is to return the full string of the tag and its children, and it was not including the comments start and end tags.

I expanded the simple one-line string join function in `node_contents_str()` to check if the tag is a `bs4.Comment` object, and if so then add back the comment tags, otherwise it will concatenate the contents as it normally was doing.

When in the paragraph rendering it returns the proper and expected full tagged content, then the function that strips out comment tags works correctly, so the comments are not included in the HTML output.

I added simple test case to cover the logic for paragraph rendering, which I think will also apply to other content blocks that are converted in this way.