### PR TITLE
None not blank str returned by  node_contents_str.

### DIFF
--- a/elifetools/tests/test_utils.py
+++ b/elifetools/tests/test_utils.py
@@ -233,6 +233,24 @@ class TestUtils(unittest.TestCase):
     def test_escape_ampersand(self, value, expected):
         self.assertEqual(utils.escape_ampersand(value), expected)
 
+    @unpack
+    @data(
+        (None, None),
+        ('', None),
+        ('<root></root>', None),
+        ('<root><p>Content <!-- comments --></p></root>',
+         '<p>Content <!-- comments --></p>'),
+        )
+    def test_node_contents_str(self, xml, expected):
+        if not xml:
+            # to test with blank values
+            tag = xml
+        else:
+            # parse the XML into tags to test with
+            soup = parser.parse_xml(xml)
+            tag = soup_body(soup)
+        self.assertEqual(utils.node_contents_str(tag), expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -270,7 +270,7 @@ def node_contents_str(tag):
     Return the contents of a tag, including it's children, as a string.
     Does not include the root/parent of the tag.
     """
-    if tag is None:
+    if not tag:
         return None
     tag_string = ''
     for child_tag in tag.children:
@@ -279,7 +279,7 @@ def node_contents_str(tag):
             tag_string += '<!--%s-->' % unicode_value(child_tag)
         else:
             tag_string += unicode_value(child_tag)
-    return tag_string
+    return tag_string if tag_string != '' else None
 
 def first_parent(tag, nodename):
     """


### PR DESCRIPTION
A small fix to PR https://github.com/elifesciences/elife-tools/pull/305 which improved comment tag parsing.

`node_contents_str()` used to return `None` in situations where the improved code was now returning a blank string `''`. I've change it back to return `None` in those situations to avoid a regression.

The `node_contents_str()` function itself never had it's own test cases either, which I added here.