### PR TITLE
Ref uri from doi for report references too.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3454,7 +3454,8 @@ def references_json(soup, html_flag=True):
             set_if_value(ref_content, "uri", ref.get("uri_text"))
         # next option is to set the uri from the doi value
         if ("uri" not in ref_content
-            and ref.get("publication-type") in ["confproc", "data", "web", "webpage", "preprint"]):
+            and ref.get("publication-type") in 
+            ["confproc", "data", "web", "webpage", "preprint", "report"]):
             if ref.get("doi"):
                 # Convert doi to uri
                 ref_content["uri"] = "https://doi.org/" + ref.get("doi")

--- a/elifetools/tests/fixtures/test_references_json/content_46.xml
+++ b/elifetools/tests/fixtures/test_references_json/content_46.xml
@@ -1,0 +1,30 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <article>
+        <back>
+            <ref-list>
+                <ref id="bib37">
+                    <element-citation publication-type="report">
+                        <person-group person-group-type="author">
+                            <name>
+                                <surname>Rumelhart</surname>
+                                <given-names>DE</given-names>
+                            </name>
+                            <name>
+                                <surname>Hinton</surname>
+                                <given-names>GE</given-names>
+                            </name>
+                            <name>
+                                <surname>Williams</surname>
+                                <given-names>RJ</given-names>
+                            </name>
+                        </person-group>
+                        <year iso-8601-date="1985">1985</year>
+                        <source>Learning Internal Representations by Error Propagation</source>
+                        <publisher-name>California Univ San Diego La Jolla Inst for Cognitive Science</publisher-name>
+                        <pub-id pub-id-type="doi">10.21236/ADA164453</pub-id>
+                    </element-citation>
+                </ref>
+            </ref-list>
+        </back>
+    </article>
+</root>

--- a/elifetools/tests/fixtures/test_references_json/content_46_expected.py
+++ b/elifetools/tests/fixtures/test_references_json/content_46_expected.py
@@ -1,0 +1,38 @@
+from collections import OrderedDict
+expected = [
+    OrderedDict([
+        ('type', 'report'),
+        ('id', 'bib37'),
+        ('date', '1985'),
+        ('authors', [
+            OrderedDict([
+                ('type', 'person'),
+                ('name', OrderedDict([
+                    ('preferred', 'DE Rumelhart'),
+                    ('index', 'Rumelhart, DE')
+                    ]))
+                ]),
+            OrderedDict([
+                ('type', 'person'),
+                ('name', OrderedDict([
+                    ('preferred', 'GE Hinton'),
+                    ('index', 'Hinton, GE')
+                    ]))
+                ]),
+            OrderedDict([
+                ('type', 'person'),
+                ('name', OrderedDict([
+                    ('preferred', 'RJ Williams'),
+                    ('index', 'Williams, RJ')
+                    ]))
+                ])
+            ]),
+        ('title', 'Learning Internal Representations by Error Propagation'),
+        ('source', 'Learning Internal Representations by Error Propagation'),
+        ('publisher', OrderedDict([
+            ('name', ['California Univ San Diego La Jolla Inst for Cognitive Science'])
+            ])),
+        ('doi', '10.21236/ADA164453'),
+        ('uri', 'https://doi.org/10.21236/ADA164453')
+    ])
+]

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1109,6 +1109,11 @@ class TestParseJats(unittest.TestCase):
           read_fixture('test_references_json', 'content_45_expected.py'),
         ),
 
+        # example of ref of type report, with a doi but no uri, uri gets filled in
+        (read_fixture('test_references_json', 'content_46.xml'),
+         read_fixture('test_references_json', 'content_46_expected.py'),
+        ),
+
         )
     @unpack
     def test_references_json_edge_cases(self, xml_content, expected):


### PR DESCRIPTION
Small change in regards to issue https://github.com/elifesciences/issues/issues/4944, where a `"report"` reference has a `doi` and not a `uri`. The parser will fill in the `uri` value in reference JSON output, the same as it does for some other types of references.