### PR TITLE
boxed-text title, do not take it from nested fig.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2378,7 +2378,12 @@ def body_block_content(tag, html_flag=True, base_url=None):
         set_if_value(tag_content, "doi", doi_uri_to_doi(object_id_doi(tag, tag.name)))
         set_if_value(tag_content, "id", tag.get("id"))
 
-        title_value = convert(title_text(tag))
+        title_parent_tag = first_parent(raw_parser.title(tag), ["boxed-text", "fig"])
+        if title_parent_tag and title_parent_tag.name == "boxed-text":
+            title_value = convert(title_text(tag))
+        else:
+            title_value = None
+
         label_value = label(tag, tag.name)
 
         caption_content = None

--- a/elifetools/tests/fixtures/test_body_block_content/content_42.xml
+++ b/elifetools/tests/fixtures/test_body_block_content/content_42.xml
@@ -1,0 +1,19 @@
+<root>
+    <boxed-text id="box2">
+        <object-id pub-id-type="doi">10.7554/eLife.46994.005</object-id>
+        <label>Box 2.</label>
+        <caption>
+            <p>content</p>
+        </caption>
+        <p>Text.</p>
+        <fig id="box2fig1" position="float">
+            <object-id pub-id-type="doi">10.7554/eLife.46994.006</object-id>
+            <label>Box 2—figure 1.</label>
+            <caption>
+                <title>Fig title.</title>
+                <p>Fig caption paragraph.</p>
+            </caption>
+            <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-46994-box2-fig1-v1.tif"/>
+        </fig>
+    </boxed-text>
+</root>

--- a/elifetools/tests/fixtures/test_body_block_content/content_42_expected.py
+++ b/elifetools/tests/fixtures/test_body_block_content/content_42_expected.py
@@ -1,0 +1,7 @@
+from collections import OrderedDict
+expected = OrderedDict([
+    ('type', 'box'),
+    ('doi', u'10.7554/eLife.46994.005'),
+    ('id', u'box2'),
+    ('title', u'Box 2.')
+    ])

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1356,6 +1356,11 @@ class TestParseJats(unittest.TestCase):
           read_fixture('test_body_block_content', 'content_41_expected.py'),
          ),
 
+        # test ignoring nested fig title as a box-text title
+         (read_fixture('test_body_block_content', 'content_42.xml'),
+          read_fixture('test_body_block_content', 'content_42_expected.py'),
+         ),
+
         )
     def test_body_block_content(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -288,7 +288,9 @@ def first_parent(tag, nodename):
     """
     if nodename is not None and type(nodename) == str:
         nodename = [nodename]
-    return first(list(filter(lambda tag: tag.name in nodename, tag.parents)))
+    if tag and tag.parents:
+        return first(list(filter(lambda tag: tag.name in nodename, tag.parents)))
+    return None
 
 def tag_ordinal(tag):
     """


### PR DESCRIPTION
Regarding issue https://github.com/elifesciences/issues/issues/4987.

After reviewing the specific XML example, there is a `<title>` of a `<fig>` inside a `<boxed-text>`. That title is set as the boxed text block title, and it shouldn't do that.

The proposed fix here is to check if the `<title>` tag's first parent tag is a `<boxed-text>` tag and not a `<fig>` tag before considering it to be the title of the box itself.

There is also a small change to `first_parent()` in `utils.py`, where in some cases `tag.parents` does not exist.

I added a test fixture example to demonstrate the expanded logic. Hopefully as well all the existing test cases are satisfied (they are for me locally), and that there are no errors in generating output of all the eLife articles subsequently.