### PR TITLE
Xmlio reparsed_tag()

### DIFF
--- a/elifetools/tests/fixtures/test_xmlio/test_reparsed_tag_01_expected.xml
+++ b/elifetools/tests/fixtures/test_xmlio/test_reparsed_tag_01_expected.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" ?>
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
-    Test &amp; 
-    <i class="a">a</i>
-     
-    <mml:math>
-        <mml:mi>K</mml:mi>
-    </mml:math>
-    .
+Test &amp; 
+<i class="a">a</i>
+ 
+<mml:math>
+<mml:mi>K</mml:mi>
+</mml:math>
+.
 </root>

--- a/elifetools/tests/fixtures/test_xmlio/test_reparsed_tag_01_expected.xml
+++ b/elifetools/tests/fixtures/test_xmlio/test_reparsed_tag_01_expected.xml
@@ -1,1 +1,10 @@
-<?xml version="1.0" ?><root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">Test &amp; <i class="a">a</i> <mml:math><mml:mi>K</mml:mi></mml:math>.</root>
+<?xml version="1.0" ?>
+<root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+    Test &amp; 
+    <i class="a">a</i>
+     
+    <mml:math>
+        <mml:mi>K</mml:mi>
+    </mml:math>
+    .
+</root>

--- a/elifetools/tests/fixtures/test_xmlio/test_reparsed_tag_01_expected.xml
+++ b/elifetools/tests/fixtures/test_xmlio/test_reparsed_tag_01_expected.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" ?><root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">Test &amp; <i class="a">a</i> <mml:math><mml:mi>K</mml:mi></mml:math>.</root>

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -165,6 +165,14 @@ class TestXmlio(unittest.TestCase):
             rough_string = ElementTree.tostring(root, encoding='unicode')
         self.assertEqual(rough_string, xml_expected)
 
+    def test_reparsed_tag(self):
+        """test parsing a string into xml.dom"""
+        tag_name = 'root'
+        tag_string = 'Test &amp; <i class="a">a</i> <mml:math><mml:mi>K</mml:mi></mml:math>.'
+        reparsed = xmlio.reparsed_tag(tag_name, tag_string)
+        self.assertEqual(
+            reparsed.toxml(), read_fixture('test_xmlio', 'test_reparsed_tag_01_expected.xml'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -171,7 +171,7 @@ class TestXmlio(unittest.TestCase):
         tag_string = 'Test &amp; <i class="a">a</i> <mml:math><mml:mi>K</mml:mi></mml:math>.'
         reparsed = xmlio.reparsed_tag(tag_name, tag_string)
         self.assertEqual(
-            reparsed.toprettyxml(indent="    "), read_fixture('test_xmlio', 'test_reparsed_tag_01_expected.xml'))
+            reparsed.toprettyxml(indent=""), read_fixture('test_xmlio', 'test_reparsed_tag_01_expected.xml'))
 
 
 if __name__ == '__main__':

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -99,16 +99,16 @@ class TestXmlio(unittest.TestCase):
         tag.tail = " and tail."
         attributes = ["class"]
         # Add a first example
-        xml = '<span><i>and</i> some <i>XML</i>.</span>'
+        xml = '<span><i>and</i> some <i id="test">XML</i>.</span>'
         reparsed = minidom.parseString(xml.encode('utf-8'))
-        parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed)
+        parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed, child_attributes=True)
         # Add another example to test more lines of code
         xml = '<span class="span"> <i>more</i> text</span>'
         reparsed = minidom.parseString(xml.encode('utf-8'))
         parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed, False, attributes)
         # Generate output and compare it
         rough_string = ElementTree.tostring(parent).decode('utf-8')
-        self.assertEqual(rough_string, '<root><i>Text</i> and tail.<span><i>and</i> some <i>XML</i>.</span><span class="span"> <i>more</i> text</span></root>')
+        self.assertEqual(rough_string, '<root><i>Text</i> and tail.<span><i>and</i> some <i id="test">XML</i>.</span><span class="span"> <i>more</i> text</span></root>')
 
     @unpack
     @data(

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -171,7 +171,7 @@ class TestXmlio(unittest.TestCase):
         tag_string = 'Test &amp; <i class="a">a</i> <mml:math><mml:mi>K</mml:mi></mml:math>.'
         reparsed = xmlio.reparsed_tag(tag_name, tag_string)
         self.assertEqual(
-            reparsed.toxml(), read_fixture('test_xmlio', 'test_reparsed_tag_01_expected.xml'))
+            reparsed.toprettyxml(indent="    "), read_fixture('test_xmlio', 'test_reparsed_tag_01_expected.xml'))
 
 
 if __name__ == '__main__':

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -12,6 +12,15 @@ xmlio can do input and output of XML, allowing it to be edited using ElementTree
 """
 
 
+# namespaces for when reparsing XML strings
+REPARSING_NAMESPACES = (
+    'xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" ' +
+    'xmlns:ali="http://www.niso.org/schemas/ali/1.0/" ' +
+    'xmlns:mml="http://www.w3.org/1998/Math/MathML" ' +
+    'xmlns:xlink="http://www.w3.org/1999/xlink"'
+)
+
+
 class CustomXMLParser(ElementTree.XMLParser):
     doctype_dict = {}
 
@@ -310,3 +319,12 @@ if __name__ == '__main__':
         reparsed_string = output(root)
 
         print(reparsed_string)
+
+
+def reparsed_tag(tag_name, tag_string, namespaces=REPARSING_NAMESPACES, attributes_text=''):
+    """given tag content and attributes, reparse to a minidom tag"""
+    open_tag_parts = [value for value in [tag_name, namespaces, attributes_text] if value]
+    open_tag = '<%s>' % ' '.join(open_tag_parts)
+    close_tag = '</%s>' % tag_name
+    tagged_string = '%s%s%s' % (open_tag, tag_string, close_tag)
+    return minidom.parseString(tagged_string.encode('utf-8'))

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -242,7 +242,8 @@ class ElifeDocumentType(minidom.DocumentType):
         writer.write(">"+newl)
 
 
-def append_minidom_xml_to_elementtree_xml(parent, xml, recursive=False, attributes=None):
+def append_minidom_xml_to_elementtree_xml(
+        parent, xml, recursive=False, attributes=None, child_attributes=False):
     """
     Recursively,
     Given an ElementTree.Element as parent, and a minidom instance as xml,
@@ -264,6 +265,10 @@ def append_minidom_xml_to_elementtree_xml(parent, xml, recursive=False, attribut
         node = xml
         tag_name = node.tagName
         new_elem = parent
+        # copy child tag attributes if present
+        if child_attributes and node.hasAttributes():
+            for name, value in node.attributes.items():
+                new_elem.set(name, value)
 
     i = 0
     for child_node in node.childNodes:
@@ -277,8 +282,8 @@ def append_minidom_xml_to_elementtree_xml(parent, xml, recursive=False, attribut
 
         elif child_node.childNodes is not None:
             new_elem_sub = SubElement(new_elem, child_node.tagName)
-            new_elem_sub = append_minidom_xml_to_elementtree_xml(new_elem_sub, child_node,
-                                                                 True, attributes)
+            new_elem_sub = append_minidom_xml_to_elementtree_xml(
+                new_elem_sub, child_node, True, attributes, child_attributes)
 
         i = i + 1
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-tools/issues/313

The function `reparsed_tag()` is used in the Crossref generation project, and I also want to use it in the decision letter parser project, hence moving it to this project into the `xmlio.py` module, which is concerned with XML input / output.

Also through some testing of real input, I noticed the attributes of tags added using the existing `append_minidom_xml_to_elementtree_xml()` function were not retained. I enhanced the logic for it, and I added a `child_attributes` parameter so it will be backwards-compatible in case some other project expected the tag attributes to be stripped away. I changed the test scenario to include tag attributes (`<i id="test">`) to make sure it had test coverage.