### PR TITLE
Drop py27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "2.7"
+  - "3.5"
 # command to install dependencies
 install: ./travis-install.sh
 script: ./travis-test.sh

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,6 @@ Tools for using article data in Python
 Supports
 ============
 
-* Python 2.7
 * Python >=3.5
 
 Non-Python dependencies

--- a/elifetools/file_utils/__init__.py
+++ b/elifetools/file_utils/__init__.py
@@ -1,7 +1,6 @@
 import os
 import io
 import importlib
-from elifetools.utils import unicode_value
 
 BASE_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 

--- a/elifetools/json_rewrite.py
+++ b/elifetools/json_rewrite.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 
 from collections import OrderedDict
-from six import iteritems
-
 import elifetools.rawJATS
 import elifetools.utils
 import elifetools.utils_html
@@ -55,7 +53,7 @@ def rewrite_references_json(json_content, rewrite_json):
     """ general purpose references json rewriting by matching the id value """
     for ref in json_content:
         if ref.get("id") and ref.get("id") in rewrite_json:
-            for key, value in iteritems(rewrite_json.get(ref.get("id"))):
+            for key, value in rewrite_json.get(ref.get("id")).items():
                 ref[key] = value
     return json_content
 
@@ -380,12 +378,12 @@ def elife_references_rewrite_json():
         if doi not in references_rewrite_json:
             references_rewrite_json[doi] = ref_json
         else:
-            for key, value in iteritems(ref_json):
+            for key, value in ref_json.items():
                 if key not in references_rewrite_json[doi]:
                     references_rewrite_json[doi][key] = value
                 else:
                     # Append dict items
-                    for k, v in iteritems(value):
+                    for k, v in value.items():
                         references_rewrite_json[doi][key][k] = v
 
     return references_rewrite_json

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -7,7 +7,6 @@ from slugify import slugify
 import elifetools.rawJATS as raw_parser
 import elifetools.json_rewrite
 from elifetools.utils import *
-from elifetools.utils import unicode_value
 from elifetools.utils_html import xml_to_html, references_author_collab
 
 
@@ -2273,7 +2272,7 @@ def body_block_paragraph_render(p_tag, html_flag=True, base_url=None):
     for child_tag in p_tag:
 
         if child_tag.name is None or body_block_content(child_tag) == {}:
-            paragraph_content = paragraph_content + unicode_value(child_tag)
+            paragraph_content = paragraph_content + str(child_tag)
 
         else:
             # Add previous paragraph content first
@@ -3189,7 +3188,7 @@ def extract_author_line_names(authors_json_data):
             author_names.append(author["name"]["preferred"])
         elif "name" in author:
             # collab
-            author_names.append(unicode_value(author["name"]))
+            author_names.append(str(author["name"]))
     return author_names
 
 def format_author_line(author_names):

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -3224,13 +3224,8 @@ def references_publisher(publisher_name=None, publisher_loc=None):
 def references_pages_range(fpage=None, lpage=None):
     range = None
     if fpage and lpage:
-        # use unichr(8211) for the hyphen because the schema is requiring it
-        try:
-            # Python 2
-            range = fpage.strip() + unichr(8211) + lpage.strip()
-        except NameError:
-            # Python 3
-            range = fpage.strip() + chr(8211) + lpage.strip()
+        # use chr(8211) for the hyphen because the schema is requiring it
+        range = fpage.strip() + chr(8211) + lpage.strip()
     elif fpage:
         range = fpage.strip()
     elif lpage:

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2858,7 +2858,7 @@ def author_phone_numbers(author, correspondence):
     phone_numbers = []
     if correspondence and "phone" in author.get("references", {}):
         for ref_id in author["references"]["phone"]:
-            for corr_ref_id, data in iteritems(correspondence):
+            for corr_ref_id, data in correspondence.items():
                 if ref_id == corr_ref_id:
                     for phone_number in data:
                         phone_numbers.append(phone_number)
@@ -2884,7 +2884,7 @@ def author_email_addresses(author, correspondence):
 
     if correspondence and "email" in author.get("references", {}):
         for ref_id in author["references"]["email"]:
-            for corr_ref_id, data in iteritems(correspondence):
+            for corr_ref_id, data in correspondence.items():
                 if ref_id == corr_ref_id:
                     for email_address in data:
                         email_addresses.append(email_address)
@@ -3898,7 +3898,7 @@ def funding_awards_json(soup):
     award_groups = full_award_groups(soup)
     if award_groups:
         for award_group_dict in award_groups:
-            for id, award_group in iteritems(award_group_dict):
+            for id, award_group in award_group_dict.items():
                 award_content = OrderedDict()
                 set_if_value(award_content, "id", id)
 

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 from ddt import ddt, data, unpack
 from elifetools import parseJATS as parser
 from elifetools import rawJATS as raw_parser
-from elifetools.utils import date_struct, unicode_value
+from elifetools.utils import date_struct
 from elifetools.file_utils import sample_xml, json_expected_file, read_fixture
 from elifetools.tests import soup_body
 

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1,7 +1,5 @@
 # coding=utf-8
 
-from __future__ import absolute_import
-
 import json
 import os
 import unittest

--- a/elifetools/tests/test_raw_parser.py
+++ b/elifetools/tests/test_raw_parser.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import unittest
 import bs4

--- a/elifetools/tests/test_utils.py
+++ b/elifetools/tests/test_utils.py
@@ -6,7 +6,6 @@ import time
 from ddt import ddt, data, unpack
 from elifetools import utils
 from elifetools import parseJATS as parser
-from elifetools.utils import unicode_value
 from elifetools.utils_html import allowed_xml_tag_fragments
 from elifetools.tests import soup_body
 
@@ -104,7 +103,7 @@ class TestUtils(unittest.TestCase):
         soup = parser.parse_xml(xml)
         tag = soup.find_all()[0]
         modified_tag = utils.remove_tag_from_tag(tag, unwanted_tag_names)
-        self.assertEqual(unicode_value(modified_tag), expected_xml)
+        self.assertEqual(str(modified_tag), expected_xml)
 
     @unpack
     @data(
@@ -151,7 +150,7 @@ class TestUtils(unittest.TestCase):
     def test_remove_doi_paragraph(self, xml, expected_xml):
         soup = parser.parse_xml(xml)
         modified_tag = utils.remove_doi_paragraph(soup_body(soup))
-        self.assertEqual(unicode_value(modified_tag), expected_xml)
+        self.assertEqual(str(modified_tag), expected_xml)
 
     @unpack
     @data(

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -9,7 +9,6 @@ from xml.dom import minidom
 
 from elifetools import xmlio
 from elifetools.file_utils import sample_xml, read_fixture, fixture_file
-from elifetools.utils import unicode_value
 
 
 @ddt

--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 from io import StringIO
 import unittest
@@ -158,11 +156,8 @@ class TestXmlio(unittest.TestCase):
     def test_rewrite_subject_group(self, xml, subjects, subject_group_type, overwrite, xml_expected):
         root = xmlio.parse(xml)
         xmlio.rewrite_subject_group(root, subjects, subject_group_type, overwrite)
-        if sys.version_info < (3,0):
-            rough_string = ElementTree.tostring(root)
-        else:
-            # unicode encoding option added in python 3
-            rough_string = ElementTree.tostring(root, encoding='unicode')
+        # unicode encoding option added in python 3
+        rough_string = ElementTree.tostring(root, encoding='unicode')
         self.assertEqual(rough_string, xml_expected)
 
     def test_reparsed_tag(self):

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -2,7 +2,6 @@ import time
 import calendar
 import re
 from collections import OrderedDict
-from six import iteritems
 from slugify import slugify
 from bs4 import Comment
 
@@ -456,7 +455,7 @@ def set_if_value(dictionary, key, value):
         dictionary[key] = value
 
 def prune_dict_of_none_values(dictionary):
-    return dict((k, v) for k, v in iteritems(dictionary) if v is not None)
+    return dict((k, v) for k, v in dictionary.items() if v is not None)
 
 
 def text_to_title(value):

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -6,14 +6,6 @@ from slugify import slugify
 from bs4 import Comment
 
 
-def unicode_value(value):
-    try:
-        return unicode(value)
-    except NameError:
-        # assume Python 3 and use str
-        return str(value)
-
-
 def subject_slug(subject, stopwords=['and', 'of']):
     "create a slug for a subject value"
     if not subject:
@@ -275,9 +267,9 @@ def node_contents_str(tag):
     for child_tag in tag.children:
         if isinstance(child_tag, Comment):
             # BeautifulSoup does not preserve comment tags, add them back
-            tag_string += '<!--%s-->' % unicode_value(child_tag)
+            tag_string += '<!--%s-->' % str(child_tag)
         else:
-            tag_string += unicode_value(child_tag)
+            tag_string += str(child_tag)
     return tag_string if tag_string != '' else None
 
 def first_parent(tag, nodename):

--- a/elifetools/utils_html.py
+++ b/elifetools/utils_html.py
@@ -1,6 +1,6 @@
 import re
 from collections import OrderedDict
-from elifetools.utils import escape_unmatched_angle_brackets, escape_ampersand, unicode_value
+from elifetools.utils import escape_unmatched_angle_brackets, escape_ampersand
 
 def xml_to_html(html_flag, xml_string, base_url=None):
     "For formatting json output into HTML friendly format"
@@ -210,5 +210,5 @@ def references_author_collab(ref_author, html_flag=True):
 
     author_json = OrderedDict()
     author_json["type"] = "group"
-    author_json["name"] = unicode_value(convert(ref_author.get("collab")))
+    author_json["name"] = str(convert(ref_author.get("collab")))
     return author_json

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 from xml.dom import minidom
@@ -17,15 +16,6 @@ REPARSING_NAMESPACES = (
     'xmlns:mml="http://www.w3.org/1998/Math/MathML" ' +
     'xmlns:xlink="http://www.w3.org/1999/xlink"'
 )
-
-
-class CustomXMLParser(ElementTree.XMLParser):
-    doctype_dict = {}
-
-    def doctype(self, name, pubid, system):
-        self.doctype_dict["name"] = name
-        self.doctype_dict["pubid"] = pubid
-        self.doctype_dict["system"] = system
 
 
 class CustomTreeBuilder(ElementTree.TreeBuilder):
@@ -51,21 +41,15 @@ def parse(filename, return_doctype_dict=False):
     for later use, set return_doctype_dict to True
     """
     doctype_dict = {}
-    # check for python version, doctype in ElementTree is deprecated 3.2 and above
-    if sys.version_info < (3,2):
-        parser = CustomXMLParser(html=0, target=None, encoding='utf-8')
-    else:
-        # Assume greater than Python 3.2, get the doctype from the TreeBuilder
-        tree_builder = CustomTreeBuilder()
-        parser = ElementTree.XMLParser(html=0, target=tree_builder, encoding='utf-8')
+
+    # Assume greater than Python 3.2, get the doctype from the TreeBuilder
+    tree_builder = CustomTreeBuilder()
+    parser = ElementTree.XMLParser(html=0, target=tree_builder, encoding='utf-8')
 
     tree = ElementTree.parse(filename, parser)
     root = tree.getroot()
 
-    if sys.version_info < (3,2):
-        doctype_dict = parser.doctype_dict
-    else:
-        doctype_dict = tree_builder.doctype_dict
+    doctype_dict = tree_builder.doctype_dict
 
     if return_doctype_dict is True:
         return root, doctype_dict

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -2,8 +2,6 @@ from __future__ import print_function
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 from xml.dom import minidom
-
-from six import iteritems
 import sys
 
 
@@ -113,7 +111,7 @@ def convert_xlink_href(root, name_map):
 
             if tag.get('{http://www.w3.org/1999/xlink}href'):
 
-                for k, v in iteritems(name_map):
+                for k, v in name_map.items():
                     # Try to match the exact name first, and if not then
                     #  try to match it without the file extension
                     if tag.get('{http://www.w3.org/1999/xlink}href') == k:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 beautifulsoup4==4.7.1
 lxml==4.3.0
 python-slugify==1.2.4
-six==1.12.0
 coverage==3.7.1
 ddt==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,5 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
     ])

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
         "beautifulsoup4",
         "lxml",
         "python-slugify",
-        "six"
     ],
     url='https://github.com/elifesciences/elife-tools',
     maintainer='eLife Sciences Publications Ltd.',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35
+envlist = py35
 [testenv]
 deps = -rrequirements.txt
 commands = coverage run -m unittest discover elifetools/tests


### PR DESCRIPTION
Issue https://github.com/elifesciences/elife-tools/issues/315, I expanded the DoD checkboxes to include five tasks which should pretty much remove all Python 2.7 support from this library.

I hope the strictness I followed is ok. I thought why not try to refactor every shred of `py27` away that I could locate. The tests are passing so I think it might be unbroken.