### PR TITLE
Add empty attributes from minidom to elementtree.

### DIFF
--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -94,18 +94,18 @@ class TestXmlio(unittest.TestCase):
         tag = SubElement(parent, 'i')
         tag.text = "Text"
         tag.tail = " and tail."
-        attributes = ["class"]
+        attributes = ["class", "empty"]
         # Add a first example
         xml = '<span><i>and</i> some <i id="test">XML</i>.</span>'
         reparsed = minidom.parseString(xml.encode('utf-8'))
         parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed, child_attributes=True)
         # Add another example to test more lines of code
-        xml = '<span class="span"> <i>more</i> text</span>'
+        xml = '<span class="span" empty=""> <i>more</i> text</span>'
         reparsed = minidom.parseString(xml.encode('utf-8'))
         parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed, False, attributes)
         # Generate output and compare it
         rough_string = ElementTree.tostring(parent).decode('utf-8')
-        self.assertEqual(rough_string, '<root><i>Text</i> and tail.<span><i>and</i> some <i id="test">XML</i>.</span><span class="span"> <i>more</i> text</span></root>')
+        self.assertEqual(rough_string, '<root><i>Text</i> and tail.<span><i>and</i> some <i id="test">XML</i>.</span><span class="span" empty=""> <i>more</i> text</span></root>')
 
     @unpack
     @data(

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -250,7 +250,7 @@ def append_minidom_xml_to_elementtree_xml(
         new_elem = SubElement(parent, tag_name)
         if attributes:
             for attribute in attributes:
-                if xml.documentElement.getAttribute(attribute):
+                if xml.documentElement.hasAttribute(attribute):
                     new_elem.set(attribute, xml.documentElement.getAttribute(attribute))
     else:
         node = xml


### PR DESCRIPTION
A bug fix with `xmlio.append_minidom_xml_to_elementtree_xml()` found when refactoring the PubMed generation library (https://github.com/elifesciences/elife-pubmed-xml-generation).

Trying to retain a minidom element's attributes when adding its data to an ElementTree element, if the tag attribute's value is blank then it is ignored and not added.

Fixing it so an attribute with a blank string as a value is added, by using `hasAttribute()` instead of `getAttribute()` in the conditional check.

Test case is updated to show the attribute with a blank value gets added to the XML.

I think we can consider this a bug fix, and it will have limited adverse effect on eLife's code running this library. As such, I don't think this is a breaking change, but a bug fix, that should be safe to integrate into other libraries.