### PR TITLE
xmlio retain XML processing instruction nodes when parsing and doing output

### DIFF
--- a/elifetools/tests/test_xmlio.py
+++ b/elifetools/tests/test_xmlio.py
@@ -1,11 +1,10 @@
-import sys
 from io import BytesIO
 import unittest
 
-from ddt import ddt, data, unpack
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 from xml.dom import minidom
+from ddt import ddt, data, unpack
 
 from elifetools import xmlio
 from elifetools.file_utils import sample_xml, read_fixture, fixture_file
@@ -38,7 +37,8 @@ class TestXmlio(unittest.TestCase):
         self.assertEqual(xmlio.output(root, 'JATS'), xml_output_expected)
 
     @unpack
-    @data(("xmlio_input.xml", "inline-graphic", 2),
+    @data(
+        ("xmlio_input.xml", "inline-graphic", 2),
         ("xmlio_input.xml", "italic", None))
     def test_get_first_element_index(self, filename, tag_name, index):
         root = xmlio.parse(sample_xml(filename))
@@ -52,7 +52,10 @@ class TestXmlio(unittest.TestCase):
         self.assertEqual(ElementTree.tostring(element).decode('utf-8'), expected_string)
 
     @unpack
-    @data(({"doc1.pdf":"doc-1.pdf", "img2.tif":"img-2.tif"}, "xmlio_input.xml", "xmlio_output_convert_xlink.xml"))
+    @data((
+        {"doc1.pdf": "doc-1.pdf", "img2.tif": "img-2.tif"},
+        "xmlio_input.xml",
+        "xmlio_output_convert_xlink.xml"))
     def test_convert_xlink_href(self, name_map, xml_input_filename, xml_expected_filename):
         xmlio.register_xmlns()
         root = xmlio.parse(sample_xml(xml_input_filename))
@@ -62,6 +65,7 @@ class TestXmlio(unittest.TestCase):
         with open(sample_xml(xml_expected_filename), "rb") as xml_file:
             xml_output_expected = xml_file.read()
         self.assertEqual(xml_output, xml_output_expected)
+        self.assertEqual(xlink_count, 2)
 
     @unpack
     @data(
@@ -72,7 +76,10 @@ class TestXmlio(unittest.TestCase):
         (b"<article/>", None, "b", "",
          '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article SYSTEM "b"><article/>'),
         (b"<article/>", "c", "", "subset",
-         '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "c"  "" [subset]><article/>'))
+         (
+             '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "c"'
+             '  "" [subset]><article/>'))
+        )
     def test_output_root(self, xml, publicId, systemId, internalSubset, xml_expected):
         encoding = 'UTF-8'
         qualifiedName = "article"
@@ -91,61 +98,72 @@ class TestXmlio(unittest.TestCase):
         # Add a first example
         xml = '<span><i>and</i> some <i id="test">XML</i>.</span>'
         reparsed = minidom.parseString(xml.encode('utf-8'))
-        parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed, child_attributes=True)
+        parent = xmlio.append_minidom_xml_to_elementtree_xml(
+            parent, reparsed, child_attributes=True)
         # Add another example to test more lines of code
         xml = '<span class="span" empty=""> <i>more</i> text</span>'
         reparsed = minidom.parseString(xml.encode('utf-8'))
-        parent = xmlio.append_minidom_xml_to_elementtree_xml(parent, reparsed, False, attributes)
+        parent = xmlio.append_minidom_xml_to_elementtree_xml(
+            parent, reparsed, False, attributes)
         # Generate output and compare it
         rough_string = ElementTree.tostring(parent).decode('utf-8')
-        self.assertEqual(rough_string, '<root><i>Text</i> and tail.<span><i>and</i> some <i id="test">XML</i>.</span><span class="span" empty=""> <i>more</i> text</span></root>')
+        self.assertEqual(rough_string, (
+            '<root><i>Text</i> and tail.<span><i>and</i> some <i id="test">XML</i>.'
+            '</span><span class="span" empty=""> <i>more</i> text</span></root>'))
 
     @unpack
     @data(
         # example of removing and adding the same heading tags
-        (fixture_file('test_xmlio', 'test_rewrite_subject_group_01.xml'),
-         ['Cell Biology', 'Plant Biology'],
-         'heading',
-         True,
-         read_fixture('test_xmlio', 'test_rewrite_subject_group_01_expected.xml')
-         ),
+        (
+            fixture_file('test_xmlio', 'test_rewrite_subject_group_01.xml'),
+            ['Cell Biology', 'Plant Biology'],
+            'heading',
+            True,
+            read_fixture('test_xmlio', 'test_rewrite_subject_group_01_expected.xml')
+        ),
         # example of removing and adding the display-channel should retain the same tag order
-        (fixture_file('test_xmlio', 'test_rewrite_subject_group_02.xml'),
-         ['Research Article'],
-         'display-channel',
-         True,
-         read_fixture('test_xmlio', 'test_rewrite_subject_group_02_expected.xml')
-         ),
+        (
+            fixture_file('test_xmlio', 'test_rewrite_subject_group_02.xml'),
+            ['Research Article'],
+            'display-channel',
+            True,
+            read_fixture('test_xmlio', 'test_rewrite_subject_group_02_expected.xml')
+        ),
         # example of appending a tag
-        (fixture_file('test_xmlio', 'test_rewrite_subject_group_03.xml'),
-         ['New Heading'],
-         'heading',
-         False,
-         read_fixture('test_xmlio', 'test_rewrite_subject_group_03_expected.xml')
-         ),
+        (
+            fixture_file('test_xmlio', 'test_rewrite_subject_group_03.xml'),
+            ['New Heading'],
+            'heading',
+            False,
+            read_fixture('test_xmlio', 'test_rewrite_subject_group_03_expected.xml')
+        ),
         # example adding a new subject type will be added to the head of the list
-        (fixture_file('test_xmlio', 'test_rewrite_subject_group_04.xml'),
-         ['New Heading'],
-         'sub-display-channel',
-         True,
-         read_fixture('test_xmlio', 'test_rewrite_subject_group_04_expected.xml')
-         ),
+        (
+            fixture_file('test_xmlio', 'test_rewrite_subject_group_04.xml'),
+            ['New Heading'],
+            'sub-display-channel',
+            True,
+            read_fixture('test_xmlio', 'test_rewrite_subject_group_04_expected.xml')
+        ),
         # example adding a new subject when none existed
-        (fixture_file('test_xmlio', 'test_rewrite_subject_group_05.xml'),
-         ['New Heading'],
-         'display-channel',
-         True,
-         read_fixture('test_xmlio', 'test_rewrite_subject_group_05_expected.xml')
-         ),
+        (
+            fixture_file('test_xmlio', 'test_rewrite_subject_group_05.xml'),
+            ['New Heading'],
+            'display-channel',
+            True,
+            read_fixture('test_xmlio', 'test_rewrite_subject_group_05_expected.xml')
+        ),
         # example removes the subject tags if an empty list of subjects is provided
-        (fixture_file('test_xmlio', 'test_rewrite_subject_group_06.xml'),
-         [],
-         'display-channel',
-         True,
-         read_fixture('test_xmlio', 'test_rewrite_subject_group_06_expected.xml'),
-         ),
+        (
+            fixture_file('test_xmlio', 'test_rewrite_subject_group_06.xml'),
+            [],
+            'display-channel',
+            True,
+            read_fixture('test_xmlio', 'test_rewrite_subject_group_06_expected.xml'),
+        ),
         )
-    def test_rewrite_subject_group(self, xml, subjects, subject_group_type, overwrite, xml_expected):
+    def test_rewrite_subject_group(self, xml, subjects, subject_group_type,
+                                   overwrite, xml_expected):
         root = xmlio.parse(xml)
         xmlio.rewrite_subject_group(root, subjects, subject_group_type, overwrite)
         # unicode encoding option added in python 3
@@ -158,7 +176,8 @@ class TestXmlio(unittest.TestCase):
         tag_string = 'Test &amp; <i class="a">a</i> <mml:math><mml:mi>K</mml:mi></mml:math>.'
         reparsed = xmlio.reparsed_tag(tag_name, tag_string)
         self.assertEqual(
-            reparsed.toprettyxml(indent=""), read_fixture('test_xmlio', 'test_reparsed_tag_01_expected.xml'))
+            reparsed.toprettyxml(indent=""),
+            read_fixture('test_xmlio', 'test_reparsed_tag_01_expected.xml'))
 
 
 @ddt
@@ -215,9 +234,9 @@ class TestOutput(unittest.TestCase):
                 '<article/>')
             ),
         (b"<article/>", None, '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article><article/>'))
-    def test_output(self, xml, type, xml_expected):
+    def test_output(self, xml, doc_type, xml_expected):
         root = xmlio.parse(BytesIO(xml))
-        xml_output = xmlio.output(root, type)
+        xml_output = xmlio.output(root, doc_type)
         self.assertEqual(xml_output.decode('utf-8'), xml_expected)
 
     @unpack
@@ -236,11 +255,10 @@ class TestOutput(unittest.TestCase):
             'DTD v1.1 20151215//EN"  "JATS-archivearticle1.dtd">'
             '<?covid-19-tdm ?>'
             '<article/>')
-        )
-        )
-    def test_output_processing_instructions(self, xml, type, xml_expected):
+        ))
+    def test_output_processing_instructions(self, xml, doc_type, xml_expected):
         root, doctype_dict, processing_instructions = xmlio.parse(BytesIO(xml), True, True)
-        xml_output = xmlio.output(root, type, doctype_dict, processing_instructions)
+        xml_output = xmlio.output(root, doc_type, doctype_dict, processing_instructions)
         self.assertEqual(xml_output.decode('utf-8'), xml_expected)
 
 

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -2,7 +2,6 @@ from io import BytesIO
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 from xml.dom import minidom
-import sys
 
 
 """
@@ -32,9 +31,10 @@ def register_xmlns():
     """
     Register namespaces globally
     """
-    ElementTree.register_namespace("mml","http://www.w3.org/1998/Math/MathML")
-    ElementTree.register_namespace("xlink","http://www.w3.org/1999/xlink")
-    ElementTree.register_namespace("ali","http://www.niso.org/schemas/ali/1.0/")
+    ElementTree.register_namespace("mml", "http://www.w3.org/1998/Math/MathML")
+    ElementTree.register_namespace("xlink", "http://www.w3.org/1999/xlink")
+    ElementTree.register_namespace("ali", "http://www.niso.org/schemas/ali/1.0/")
+
 
 def parse(filename, return_doctype_dict=False, return_processing_instructions=False):
     """
@@ -74,6 +74,7 @@ def parse(filename, return_doctype_dict=False, return_processing_instructions=Fa
     else:
         return root
 
+
 def add_tag_before(tag_name, tag_text, parent_tag, before_tag_name):
     """
     Helper function to refactor the adding of new tags
@@ -82,7 +83,7 @@ def add_tag_before(tag_name, tag_text, parent_tag, before_tag_name):
     new_tag = Element(tag_name)
     new_tag.text = tag_text
     if get_first_element_index(parent_tag, before_tag_name):
-        parent_tag.insert( get_first_element_index(parent_tag, before_tag_name) - 1, new_tag)
+        parent_tag.insert(get_first_element_index(parent_tag, before_tag_name) - 1, new_tag)
     return parent_tag
 
 
@@ -195,8 +196,6 @@ def output(root, type='JATS', doctype_dict=None, processing_instructions=None):
 
     encoding = 'UTF-8'
 
-    namespaceURI = None
-
     doctype = build_doctype(qualifiedName, publicId, systemId)
 
     return output_root(root, doctype, encoding, processing_instructions)
@@ -213,7 +212,7 @@ def output_root(root, doctype, encoding, processing_instructions=None):
         for pi_node in processing_instructions:
             reparsed.insertBefore(pi_node, reparsed.documentElement)
 
-    #reparsed_string =  reparsed.toprettyxml(indent="\t", encoding = encoding)
+    # reparsed_string =  reparsed.toprettyxml(indent="\t", encoding = encoding)
     reparsed_string = reparsed.toxml(encoding=encoding)
 
     return reparsed_string
@@ -301,9 +300,9 @@ def append_minidom_xml_to_elementtree_xml(
         i = i + 1
 
     # Debug
-    #encoding = 'utf-8'
-    #rough_string = ElementTree.tostring(parent, encoding)
-    #print rough_string
+    # encoding = 'utf-8'
+    # rough_string = ElementTree.tostring(parent, encoding)
+    # print rough_string
 
     return parent
 

--- a/elifetools/xmlio.py
+++ b/elifetools/xmlio.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 from xml.dom import minidom
@@ -35,23 +36,40 @@ def register_xmlns():
     ElementTree.register_namespace("xlink","http://www.w3.org/1999/xlink")
     ElementTree.register_namespace("ali","http://www.niso.org/schemas/ali/1.0/")
 
-def parse(filename, return_doctype_dict=False):
+def parse(filename, return_doctype_dict=False, return_processing_instructions=False):
     """
     to extract the doctype details from the file when parsed and return the data
     for later use, set return_doctype_dict to True
     """
     doctype_dict = {}
+    processing_instructions = []
+
+    # support BytesIO or actual files
+    try:
+        xml_bytes = filename.getvalue()
+    except AttributeError:
+        with open(filename, 'rb') as open_file:
+            xml_bytes = open_file.read()
+
+    # collect processing instruction nodes using minidom
+    with minidom.parseString(xml_bytes) as dom:
+        for node in dom.childNodes:
+            if isinstance(node, minidom.ProcessingInstruction):
+                processing_instructions.append(node)
 
     # Assume greater than Python 3.2, get the doctype from the TreeBuilder
     tree_builder = CustomTreeBuilder()
     parser = ElementTree.XMLParser(html=0, target=tree_builder, encoding='utf-8')
+    new_file = BytesIO(xml_bytes)
+    tree = ElementTree.parse(new_file, parser)
 
-    tree = ElementTree.parse(filename, parser)
     root = tree.getroot()
 
     doctype_dict = tree_builder.doctype_dict
 
-    if return_doctype_dict is True:
+    if return_doctype_dict is True and return_processing_instructions is True:
+        return root, doctype_dict, processing_instructions
+    elif return_doctype_dict is True:
         return root, doctype_dict
     else:
         return root
@@ -160,7 +178,7 @@ def rewrite_subject_group(root, subjects, subject_group_type, overwrite=True):
     return count
 
 
-def output(root, type='JATS', doctype_dict=None):
+def output(root, type='JATS', doctype_dict=None, processing_instructions=None):
 
     if doctype_dict is not None:
         publicId = doctype_dict.get('pubid')
@@ -181,15 +199,19 @@ def output(root, type='JATS', doctype_dict=None):
 
     doctype = build_doctype(qualifiedName, publicId, systemId)
 
-    return output_root(root, doctype, encoding)
+    return output_root(root, doctype, encoding, processing_instructions)
 
 
-def output_root(root, doctype, encoding):
+def output_root(root, doctype, encoding, processing_instructions=None):
     rough_string = ElementTree.tostring(root, encoding)
 
     reparsed = minidom.parseString(rough_string)
     if doctype:
         reparsed.insertBefore(doctype, reparsed.documentElement)
+
+    if processing_instructions:
+        for pi_node in processing_instructions:
+            reparsed.insertBefore(pi_node, reparsed.documentElement)
 
     #reparsed_string =  reparsed.toprettyxml(indent="\t", encoding = encoding)
     reparsed_string = reparsed.toxml(encoding=encoding)


### PR DESCRIPTION
A timely request to add a particular XML processing instruction tag if the XML is rewritten. The existing `parse()` and `output()` logic in the `xmlio.py` module does not retain or understand these.

I have found a way to record them using `minidom` (since `ElementTree` ignores them), and then these minidom nodes can be passed to the output function, where they can be added back again.

It is backwards compatible, however I would like to clean up `parse()` at some point, I would like to get this code change to the next stage so it can be tested in real workflows.

I linted the code on the two files changed here too.
