### PR TITLE
Structured abstract parsing

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2785,7 +2785,8 @@ def render_abstract_json(abstract_tag):
         if body_block_content(child_tag) != {}:
             if "content" not in abstract_json:
                  abstract_json["content"] = []
-            abstract_json["content"].append(body_block_content(child_tag))
+            # supports p or sec tags by recursive rendering the tag then keep the first element
+            abstract_json["content"].append(body_block_content_render(child_tag)[0])
     return abstract_json
 
 

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2397,6 +2397,12 @@ def body_block_content(tag, html_flag=True, base_url=None):
         set_if_value(tag_content, "id", tag.get("id"))
         set_if_value(tag_content, "title", convert(title_text(tag, direct_sibling_only=True)))
 
+    if tag.name == "related-object":
+        # related-object tag for clinical trial data in structured abstract sec tag
+        tag_content["type"] = "paragraph"
+        set_if_value(tag_content, "id", tag.get("id"))
+        tag_content["text"] = convert(clean_whitespace(str(tag)))
+
     elif tag.name == "boxed-text":
         tag_content["type"] = "box"
         set_if_value(tag_content, "doi", doi_uri_to_doi(object_id_doi(tag, tag.name)))

--- a/elifetools/tests/fixtures/test_abstract_json/content_04.xml
+++ b/elifetools/tests/fixtures/test_abstract_json/content_04.xml
@@ -1,0 +1,36 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <front>
+        <article-meta>
+            <abstract>
+                <sec>
+                    <title>Objectives</title>
+                    <p>To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5 years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed.</p>
+                </sec>
+                <sec>
+                    <title>Design</title>
+                    <p>A cross-sectional hospital-based surveillance study.</p>
+                </sec>
+                <sec>
+                    <title>Setting</title>
+                    <p>5 reference paediatric hospitals across Abidjan.</p>
+                </sec>
+                <sec>
+                    <title>Participants</title>
+                    <p>Children aged less than 5 years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study.</p>
+                </sec>
+                <sec>
+                    <title>Primary and secondary outcome measures</title>
+                    <p>The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR.</p>
+                </sec>
+                <sec>
+                    <title>Results</title>
+                    <p>Of 357 enrolled children (mean age 13.6±11.14 months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6–11 months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains.</p>
+                </sec>
+                <sec>
+                    <title>Conclusions</title>
+                    <p>RVGE causes substantial morbidity among children under 5 years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.</p>
+                </sec>
+            </abstract>
+        </article-meta>
+    </front>
+</root>

--- a/elifetools/tests/fixtures/test_abstract_json/content_04_expected.py
+++ b/elifetools/tests/fixtures/test_abstract_json/content_04_expected.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+from collections import OrderedDict
+expected = OrderedDict([
+    ('content', [
+        OrderedDict([
+            ('type', 'section'),
+            ('title', 'Objectives'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5\u2005years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('title', 'Design'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'A cross-sectional hospital-based surveillance study.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('title', 'Setting'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', '5 reference paediatric hospitals across Abidjan.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('title', 'Participants'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'Children aged less than 5\u2005years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('title', 'Primary and secondary outcome measures'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('title', 'Results'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'), ('text', 'Of 357 enrolled children (mean age 13.6±11.14\u2005months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6–11\u2005months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('title', 'Conclusions'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'RVGE causes substantial morbidity among children under 5\u2005years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.')
+                ])
+            ])
+        ])
+    ])
+])

--- a/elifetools/tests/fixtures/test_abstract_json/content_05.xml
+++ b/elifetools/tests/fixtures/test_abstract_json/content_05.xml
@@ -1,0 +1,32 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <front>
+        <article-meta>
+            <abstract>
+                <sec id="abs1">
+                    <title>Background:</title>
+                    <p>Background text.</p>
+                </sec>
+                <sec id="abs2">
+                    <title>Methods:</title>
+                    <p>Methods text.</p>
+                </sec>
+                <sec id="abs3">
+                    <title>Results:</title>
+                    <p>Results text.</p>
+                </sec>
+                <sec id="abs4">
+                    <title>Conclusions:</title>
+                    <p>Conclusions text.</p>
+                </sec>
+                <sec id="abs5">
+                    <title>Funding</title>
+                    <p> Funded by X, Y and Z.</p>
+                </sec>
+                <sec id="abs6">
+                    <title>Clinical trial number:</title>
+                    <related-object id="CT1" source-type="clinical-trials-registry" source-id="ClinicalTrials.gov" source-id-type="registry-name" document-id="NCT02968459" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT02968459">NCT02968459.</related-object>
+                </sec>
+            </abstract>
+        </article-meta>
+    </front>
+</root>

--- a/elifetools/tests/fixtures/test_abstract_json/content_05_expected.py
+++ b/elifetools/tests/fixtures/test_abstract_json/content_05_expected.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+from collections import OrderedDict
+expected = OrderedDict([
+    ('content', [
+        OrderedDict([
+            ('type', 'section'),
+            ('id', 'abs1'),
+            ('title', 'Background:'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'Background text.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('id', 'abs2'),
+            ('title', 'Methods:'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'Methods text.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('id', 'abs3'),
+            ('title', 'Results:'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'Results text.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('id', 'abs4'),
+            ('title', 'Conclusions:'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'Conclusions text.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('id', 'abs5'),
+            ('title', 'Funding'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', 'Funded by X, Y and Z.')
+                ])
+            ])
+        ]),
+        OrderedDict([
+            ('type', 'section'),
+            ('id', 'abs6'),
+            ('title', 'Clinical trial number:'),
+            ('content', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('id', 'CT1'),
+                    ('text', (
+                        '<a href="https://clinicaltrials.gov/show/NCT02968459">NCT02968459.</a>'))
+                ])
+            ])
+        ])
+    ])
+])

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1594,6 +1594,11 @@ class TestParseJats(unittest.TestCase):
          read_fixture('test_abstract_json', 'content_04_expected.py'),
          ),
 
+        # structured abstract elife example
+        (read_fixture('test_abstract_json', 'content_05.xml'),
+         read_fixture('test_abstract_json', 'content_05_expected.py'),
+         ),
+
         )
     def test_abstract_json(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -1589,6 +1589,11 @@ class TestParseJats(unittest.TestCase):
          read_fixture('test_abstract_json', 'content_03_expected.py'),
          ),
 
+        # structured abstract example based on BMJ Open bmjopen-4-e003269.xml
+        (read_fixture('test_abstract_json', 'content_04.xml'),
+         read_fixture('test_abstract_json', 'content_04_expected.py'),
+         ),
+
         )
     def test_abstract_json(self, xml_content, expected):
         soup = parser.parse_xml(xml_content)

--- a/elifetools/tests/test_utils_html.py
+++ b/elifetools/tests/test_utils_html.py
@@ -119,9 +119,28 @@ class TestUtilsHtml(unittest.TestCase):
         (True, u'<p>&</p>', None,
          u'<p>&amp;</p>'),
 
+        # related-object tag, can be found in a structured abstract
+        (True, (
+            '<related-object id="CT1" source-type="clinical-trials-registry" '
+            'source-id="ClinicalTrials.gov" source-id-type="registry-name" '
+            'document-id="NCT02968459" document-id-type="clinical-trial-number" '
+            'xlink:href="https://clinicaltrials.gov/show/NCT02968459">NCT02968459.'
+            '</related-object>'), None,
+         '<a href="https://clinicaltrials.gov/show/NCT02968459">NCT02968459.</a>'),
+
         )
     def test_xml_to_html(self, html_flag, xml_string, base_url, expected):
         self.assertEqual(utils_html.xml_to_html(html_flag, xml_string, base_url), expected)
+
+
+    def test_replace_related_object_tagsl(self):
+        """test when link is not prefaced with an internet scheme prefix"""
+        tag_string = (
+            '<related-object xlink:href="clinicaltrials.gov/show/NCT02968459">NCT02968459.'
+            '</related-object>')
+        expected = '<a href="http://clinicaltrials.gov/show/NCT02968459">NCT02968459.</a>'
+        self.assertEqual(utils_html.replace_related_object_tags(tag_string), expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/4622

There was an existing test fixture XML, based on a BMJ Open article, the tests for which show how the older, more basic `abstract()` function omits the section title values and only retains the paragraph content. This is still the case for now.

The more recent function `abstract_json()`, which calls `render_abstract_json()`, was created to produce abstract content in an eLife JSON format that validates against the RAML schema.

When rendering the abstract's content, using `body_block_content_render()`, which recursively traverses child tags in the XML, instead of using just `body_block_content()`, the output includes `section` and `paragraph` blocks in the structured format.

In the eLife XML example, there is also a `<related-object>` tag, holding the clinical trial information. For now, it is agreed this can be converted to a `paragraph` block, and the `<related-object>` tag itself, when converted to HTML, can be an `<a>` anchor tag.

I think I left in parsing the `@id` attribute of the `<related-object>` tag, and it gets added to the `paragraph` block as an attribute. I believe, in the RAML schema, there is no `@id` attribute listed for a `paragraph`, but I think if it remains there the RAML schema validation will not care. If we should remove the `id` attribute from the output, that option is possible.

These code changes do not cause any other existing test cases in this library to fail. If we parse XML which has only `<p>` tags in the `<abstract>` tag, then the output should remain the same as it was, and it will continue to be valid against the RAML article `v2` schema.

In order to support abstracts that also include `section` blocks, we can introduce this parser change with little risk, and then the adapatations to the RAML schema can continue.

I don't know the exact timing of when structured abstract XML for eLife will appear, except to know we need to do all this work in preparation before the first structured abstract can be allowed to pass through the workflows and displayed on journal.