### PR TITLE
Upgrade version of coverage to fix tests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.7.1
 lxml==4.3.0
 python-slugify==1.2.4
-coverage==3.7.1
+coverage==5.1
 ddt==1.1.0


### PR DESCRIPTION
Tests are failing using jenkins for what looks like when trying to submit coverage data to coveralls, the `coverage==3.7.1` is too old. Here, try upgrading to `coverage==5.1`, which seems to be the latest it is trying to install in order to support `coveralls` module.