### PR TITLE
Require a date tag for version history data.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -127,6 +127,7 @@ def impact_statement(soup):
         return node_contents_str(first(extract_nodes(tag, "meta-value")))
     return ""
 
+
 def version_history(soup, html_flag=True):
     "extract the article version history details"
     convert = lambda xml_string: xml_to_html(html_flag, xml_string)
@@ -135,18 +136,23 @@ def version_history(soup, html_flag=True):
     for tag in related_object_tags:
         article_version = OrderedDict()
         date_tag = first(raw_parser.date(tag))
-        if date_tag:
-            copy_attribute(date_tag.attrs, 'date-type', article_version, 'version')
-            (day, month, year) = ymd(date_tag)
-            article_version['day'] = day
-            article_version['month'] = month
-            article_version['year'] = year
-            article_version['date'] = date_struct_nn(year, month, day)
+
+        if not date_tag:
+            continue
+
+        copy_attribute(date_tag.attrs, 'date-type', article_version, 'version')
+        (day, month, year) = ymd(date_tag)
+        article_version['day'] = day
+        article_version['month'] = month
+        article_version['year'] = year
+        article_version['date'] = date_struct_nn(year, month, day)
+
         copy_attribute(tag.attrs, 'xlink:href', article_version, 'xlink_href')
         set_if_value(article_version, "comment",
                      convert(node_contents_str(first(raw_parser.comment(tag)))))
         version_history.append(article_version)
     return version_history
+
 
 def format_related_object(related_object):
     return related_object["id"], {}


### PR DESCRIPTION
Should be a non-breaking change to `version_history()`.

There are plans to parse `<related-object>` tags from the article meta which will contain clinical trial data. That would potentially end up being picked up by the `version_history()` function and adding some extra, blank, data.

To prepare for this, I have changed it so only if there is a `<date>` tag will the `<related-object>` data be considered for inclusion in the version history.

eLife did not end up using version history so much yet, so it would have little or no impact anyway. Any other non-eLife XML with version history should also be compatible with this requirement that a version history element has a date.