### PR TITLE
Parse clinical trials related-object tags.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -154,6 +154,23 @@ def version_history(soup, html_flag=True):
     return version_history
 
 
+def clinical_trials(soup):
+    clinical_trials = []
+    related_object_tags = raw_parser.related_object(raw_parser.article_meta(soup))
+    # only consider related-object tags that have a source-id-type attribute
+    for tag in [tag for tag in related_object_tags if 'source-id-type' in tag.attrs]:
+        clinical_trial = OrderedDict()
+        for attribute in [
+                'id', 'content-type', 'document-id', 'document-id-type',
+                'source-id', 'source-id-type', 'source-type']:
+            copy_attribute(tag.attrs, attribute, clinical_trial)
+        clinical_trial['text'] = tag.text
+        copy_attribute(tag.attrs, 'xlink:href', clinical_trial, 'xlink_href')
+        if clinical_trial:
+            clinical_trials.append(clinical_trial)
+    return clinical_trials
+
+
 def format_related_object(related_object):
     return related_object["id"], {}
 

--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -166,8 +166,7 @@ def clinical_trials(soup):
             copy_attribute(tag.attrs, attribute, clinical_trial)
         clinical_trial['text'] = tag.text
         copy_attribute(tag.attrs, 'xlink:href', clinical_trial, 'xlink_href')
-        if clinical_trial:
-            clinical_trials.append(clinical_trial)
+        clinical_trials.append(clinical_trial)
     return clinical_trials
 
 

--- a/elifetools/tests/fixtures/test_clinical_trials/content_01.xml
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_01.xml
@@ -1,0 +1,5 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <front>
+        <article-meta></article-meta>
+    </front>
+</root>

--- a/elifetools/tests/fixtures/test_clinical_trials/content_01_expected.py
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_01_expected.py
@@ -1,0 +1,1 @@
+expected = []

--- a/elifetools/tests/fixtures/test_clinical_trials/content_02.xml
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_02.xml
@@ -1,0 +1,15 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <front>
+        <article-meta>
+            <abstract>
+                <sec id="abs6">
+                    <title>Clinical trial number:</title>
+                    <p>
+                        <related-object id="CT1" source-type="clinical-trials-registry" source-id="ClinicalTrials.gov" source-id-type="registry-name" document-id="NCT02836002" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT02836002">NCT02836002</related-object>.
+                    </p>
+                </sec>
+                </abstract>
+            </abstract>
+        </article-meta>
+    </front>
+</root>

--- a/elifetools/tests/fixtures/test_clinical_trials/content_02_expected.py
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_02_expected.py
@@ -1,0 +1,14 @@
+from collections import OrderedDict
+
+expected = [
+    OrderedDict([
+        ('id', 'CT1'),
+        ('document-id', 'NCT02836002'),
+        ('document-id-type', 'clinical-trial-number'), 
+        ('source-id', 'ClinicalTrials.gov'),
+        ('source-id-type', 'registry-name'),
+        ('source-type', 'clinical-trials-registry'), 
+        ('text', 'NCT02836002'), 
+        ('xlink_href', 'https://clinicaltrials.gov/show/NCT02836002'),
+        ]),
+    ]

--- a/elifetools/tests/fixtures/test_clinical_trials/content_03.xml
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_03.xml
@@ -1,0 +1,15 @@
+<root xmlns:xlink="http://www.w3.org/1999/xlink">
+    <front>
+        <article-meta>
+            <related-object id="CT1" content-type="post-result" source-type="clinical-trials-registry" source-id="ClinicalTrials.gov" source-id-type="registry-name" document-id="NCT02836002" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT02836002">NCT02836002</related-object>
+            <related-object id="CT1" content-type="preResult" source-type="clinical-trials-registry" source-id="10.18810/clinical-trials-gov" source-id-type="crossref-doi" document-id="NCT04094727" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT04094727">NCT04094727</related-object>
+            <related-object ext-link-type="url" xlink:href="https://elifesciences.org/articles/e00666v1">
+                <date date-type="v1" iso-8601-date="2016-04-25">
+                    <day>25</day>
+                    <month>04</month>
+                    <year>2016</year>
+                </date>
+            </related-object>
+        </article-meta>
+    </front>
+</root>

--- a/elifetools/tests/fixtures/test_clinical_trials/content_03.xml
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_03.xml
@@ -1,8 +1,8 @@
 <root xmlns:xlink="http://www.w3.org/1999/xlink">
     <front>
         <article-meta>
-            <related-object id="CT1" content-type="post-result" source-type="clinical-trials-registry" source-id="ClinicalTrials.gov" source-id-type="registry-name" document-id="NCT02836002" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT02836002">NCT02836002</related-object>
-            <related-object id="CT1" content-type="preResult" source-type="clinical-trials-registry" source-id="10.18810/clinical-trials-gov" source-id-type="crossref-doi" document-id="NCT04094727" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT04094727">NCT04094727</related-object>
+            <related-object id="CT1" content-type="post-results" source-type="clinical-trials-registry" source-id="ClinicalTrials.gov" source-id-type="registry-name" document-id="NCT02836002" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT02836002">NCT02836002</related-object>
+            <related-object id="CT1" content-type="preResults" source-type="clinical-trials-registry" source-id="10.18810/clinical-trials-gov" source-id-type="crossref-doi" document-id="NCT04094727" document-id-type="clinical-trial-number" xlink:href="https://clinicaltrials.gov/show/NCT04094727">NCT04094727</related-object>
             <related-object ext-link-type="url" xlink:href="https://elifesciences.org/articles/e00666v1">
                 <date date-type="v1" iso-8601-date="2016-04-25">
                     <day>25</day>

--- a/elifetools/tests/fixtures/test_clinical_trials/content_03_expected.py
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_03_expected.py
@@ -1,0 +1,26 @@
+from collections import OrderedDict
+
+expected = [
+    OrderedDict([
+        ('id', 'CT1'),
+        ('content-type', 'post-result'),
+        ('document-id', 'NCT02836002'),
+        ('document-id-type', 'clinical-trial-number'),
+        ('source-id', 'ClinicalTrials.gov'),
+        ('source-id-type', 'registry-name'),
+        ('source-type', 'clinical-trials-registry'),
+        ('text', 'NCT02836002'),
+        ('xlink_href', 'https://clinicaltrials.gov/show/NCT02836002'),
+        ]),
+    OrderedDict([
+        ('id', 'CT1'),
+        ('content-type', 'preResult'),
+        ('document-id', 'NCT04094727'),
+        ('document-id-type', 'clinical-trial-number'),
+        ('source-id', '10.18810/clinical-trials-gov'),
+        ('source-id-type', 'crossref-doi'),
+        ('source-type', 'clinical-trials-registry'),
+        ('text', 'NCT04094727'),
+        ('xlink_href', 'https://clinicaltrials.gov/show/NCT04094727'),
+        ])
+    ]

--- a/elifetools/tests/fixtures/test_clinical_trials/content_03_expected.py
+++ b/elifetools/tests/fixtures/test_clinical_trials/content_03_expected.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 expected = [
     OrderedDict([
         ('id', 'CT1'),
-        ('content-type', 'post-result'),
+        ('content-type', 'post-results'),
         ('document-id', 'NCT02836002'),
         ('document-id-type', 'clinical-trial-number'),
         ('source-id', 'ClinicalTrials.gov'),
@@ -14,7 +14,7 @@ expected = [
         ]),
     OrderedDict([
         ('id', 'CT1'),
-        ('content-type', 'preResult'),
+        ('content-type', 'preResults'),
         ('document-id', 'NCT04094727'),
         ('document-id-type', 'clinical-trial-number'),
         ('source-id', '10.18810/clinical-trials-gov'),

--- a/elifetools/tests/test_parse_jats.py
+++ b/elifetools/tests/test_parse_jats.py
@@ -2450,6 +2450,28 @@ class TestParseJats(unittest.TestCase):
 
     @unpack
     @data(
+        (
+            read_fixture('test_clinical_trials', 'content_01.xml'),
+            read_fixture('test_clinical_trials', 'content_01_expected.py'),
+        ),
+        # eLife example
+        (
+            read_fixture('test_clinical_trials', 'content_02.xml'),
+            read_fixture('test_clinical_trials', 'content_02_expected.py'),
+        ),
+        # example with all tag attributes and a related-object tag to ignore
+        (
+            read_fixture('test_clinical_trials', 'content_03.xml'),
+            read_fixture('test_clinical_trials', 'content_03_expected.py'),
+        ),
+        )
+    def test_clinical_trials(self, xml_content, expected):
+        soup = parser.parse_xml(xml_content)
+        tag_content = parser.clinical_trials(soup_body(soup))
+        self.assertEqual(expected, tag_content)
+
+    @unpack
+    @data(
         ('',
          []
         ),


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-crossref-feed/issues/146

To support adding clinical trials data to Crossref deposits, the data must be parsed from the article XML. They are specified in `<related-object>` tags present in the `<article-meta>` tag, sometimes inside the `<abstract>` but maybe not.

Since some other `<related-object>` tags may be present in the article-meta, it only looks for tags that have a `@source-id-type` attribute.

The data structure returned is a list of `OrderedDict()` containing key value data. This will later be used to populate objects and end up in Crossref and PubMed deposits.