### PR TITLE
Bug fix abstract_xml() to be non-destructive.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -604,9 +604,10 @@ def abstract(soup):
 
 
 def abstract_xml(soup, strip_doi_paragraphs=True, abstract_type=None):
-    abstract_tag = first(raw_parser.abstract(soup, abstract_type))
-    if not abstract_tag:
+    original_abstract_tag = first(raw_parser.abstract(soup, abstract_type))
+    if not original_abstract_tag:
         return None
+    abstract_tag = copy.copy(original_abstract_tag)
     if strip_doi_paragraphs and raw_parser.paragraph(abstract_tag):
         for p_tag in raw_parser.paragraph(abstract_tag):
             if paragraph_is_only_doi(p_tag) or starts_with_doi(p_tag):


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/elife-tools/pull/324

After testing this new function in practice, if you call `abstract_xml()` and other abstract functions on the same `soup` object, and because `abstract_xml()` uses `clear()` to get rid of DOI paragraphs, then the abstract in the soup is altered.

The fix here is to make a copy of the abstract tag object before altering it.