### PR TITLE
Use decompose instead of clear removing p tags.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -611,7 +611,7 @@ def abstract_xml(soup, strip_doi_paragraphs=True, abstract_type=None):
     if strip_doi_paragraphs and raw_parser.paragraph(abstract_tag):
         for p_tag in raw_parser.paragraph(abstract_tag):
             if paragraph_is_only_doi(p_tag) or starts_with_doi(p_tag):
-                p_tag.clear()
+                p_tag.decompose()
     # add in common JATS XML namespaces which are getting lost
     for namespace in XML_NAMESPACES:
         prefix_match = '<%s' % namespace.get('prefix')

--- a/elifetools/tests/fixtures/test_abstract_xml/content_02_expected.py
+++ b/elifetools/tests/fixtures/test_abstract_xml/content_02_expected.py
@@ -3,6 +3,6 @@ expected = (
     '<abstract id="ab1" xmlns:mml="http://www.w3.org/1998/Math/MathML">\n'
     '<object-id pub-id-type="doi">10.7554/eLife.00001.001</object-id>\n'
     '<p>Example <sub>in</sub> <italic>cis</italic> <sc>or</sc> <italic>trans</italic> <underline>and</underline> <italic>Gfrα2</italic> <inline-formula><mml:math id="inf1"><mml:mstyle displaystyle="true" scriptlevel="0"><mml:mrow><mml:munder><mml:mo/><mml:mi>m</mml:mi></mml:munder><mml:mrow><mml:msub><mml:mover accent="true"><mml:mi>p</mml:mi><mml:mo/></mml:mover><mml:mi>m</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:mrow></mml:mstyle></mml:math></inline-formula> <sup>by</sup> <bold>its</bold> co-receptors as *p&lt;0.05 &gt;0.25% <xref ref-type="bibr" rid="bib25">Schneider et al., 2006</xref> and ligands.</p>\n'
-    '<p/>\n'
+    '\n'
     '</abstract>')
 


### PR DESCRIPTION
Bug fix 2 for PR https://github.com/elifesciences/elife-tools/pull/324

Instead of using `clear()` on the paragraph tags removed from `abstract_xml()`, use `decompose()`.

I didn't notice in the test fixture there was an empty `<p/>` tag in the output and we don't want that.

The new line character remains, if the XML file had new lines.