### PR TITLE
elocation_id() only return value from article-meta.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -100,7 +100,7 @@ def lpage(soup):
     return node_text(first(raw_parser.lpage(raw_parser.article_meta(soup))))
 
 def elocation_id(soup):
-    return node_text(first(raw_parser.elocation_id(soup)))
+    return node_text(first(raw_parser.elocation_id(raw_parser.article_meta(soup))))
 
 def research_organism(soup):
     "Find the research-organism from the set of kwd-group tags"


### PR DESCRIPTION
Bug fix for the `parseJATS.elocation_id()` function.

On non-eLife XML samples, if the article itself has no `<elocation-id>` tag, but there is a citation with one, then it returns the value from the first citation.

Instead, only look for the value in the `<article-meta>` tag content.

This is similar to how `issue()` is done already.
