### PR TITLE
remove_tag() and remove_tag_and_text()

### DIFF
--- a/elifetools/tests/test_utils.py
+++ b/elifetools/tests/test_utils.py
@@ -234,6 +234,25 @@ class TestUtils(unittest.TestCase):
 
     @unpack
     @data(
+        (None, None, ''),
+        ('p', '<p class="p1">Paragraph.</p>', 'Paragraph.'),
+        ('bold', '<p>\n<bold>One<bold> <bold>two</bold>\n</p>', '<p>One two</p>'),
+        ('italic', '<p><italic><italic>Very italic.</italic></italic></p>', '<p>Very italic.</p>'),
+        )
+    def test_remove_tag(self, tag_name, string, expected):
+        self.assertEqual(utils.remove_tag(tag_name, string), expected)
+
+    @unpack
+    @data(
+        (None, None, ''),
+        ('p', '<p class="p1">Paragraph.</p>', ''),
+        ('italic', '<p><italic><italic>Very italic.</italic></italic></p>', '<p></p>'),
+        )
+    def test_remove_tag_and_text(self, tag_name, string, expected):
+        self.assertEqual(utils.remove_tag_and_text(tag_name, string), expected)
+
+    @unpack
+    @data(
         (None, None),
         ('', None),
         ('<root></root>', None),

--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -525,6 +525,19 @@ def escape_ampersand(string):
     string = re.sub(r"&(?!" + start_with_match + ")", '&amp;', string)
     return string
 
+
+def remove_tag(tag_name, string):
+    "remove open tag and its attributes and remove close tag from an XML string"
+    pattern = r'\n*</?%s.*?>\n*' % tag_name
+    return re.sub(pattern, '', string) if string else ''
+
+
+def remove_tag_and_text(tag_name, string):
+    "remove open tag and close tag and the contents between them from an XML string"
+    pattern = r'\n*<%s.*?>.*?</%s>\n*' % (tag_name, tag_name)
+    return remove_tag(tag_name, re.sub(pattern, '', string)) if string else ''
+
+
 def references_author_person(ref_author):
     author_json = OrderedDict()
     author_json["type"] = "person"


### PR DESCRIPTION
Starting from adding structured abstract enhancements to the https://github.com/elifesciences/elife-crossref-xml-generation project, continuing on to enhancing https://github.com/elifesciences/elife-pubmed-xml-generation I needed to use these two tag removal functions to alter the abstract XML.

For reuse and to reduce duplicate code, I think the best home for these two functions, `remove_tag()` and `remove_tag_and_text()`, will be here in the `utils.py` module.

I added test scenarios specifically for these two functions based on some real examples containing new line characters and one imagined edge case.

These are all new functions with no backwards compatibility risks.