### PR TITLE
Fix render of disp-formula inside disp-quote.

### DIFF
--- a/elifetools/parseJATS.py
+++ b/elifetools/parseJATS.py
@@ -2497,10 +2497,12 @@ def body_block_content(tag, html_flag=True, base_url=None):
             tag_content["type"] = "quote"
             block_array_name = "text"
         for child_tag in tag:
-            if body_block_content(child_tag) != {}:
-                if block_array_name not in tag_content:
-                    tag_content[block_array_name] = []
-                tag_content[block_array_name].append(body_block_content(child_tag, base_url=base_url))
+            if child_tag.name == "p":
+                for block_content in body_block_paragraph_render(child_tag, base_url=base_url):
+                    if block_content != {}:
+                        if block_array_name not in tag_content:
+                            tag_content[block_array_name] = []
+                        tag_content[block_array_name].append(block_content)
 
     elif tag.name == "table-wrap":
         # figure wrap

--- a/elifetools/tests/fixtures/test_body_block_content_render/content_32.xml
+++ b/elifetools/tests/fixtures/test_body_block_content_render/content_32.xml
@@ -1,0 +1,9 @@
+<disp-quote content-type="editor-comment" xmlns:mml="http://www.w3.org/1998/Math/MathML">
+    <p>2) The competition term χ <sub>i</sub> requires renormalization, ... such as
+    <disp-formula id="equ2">
+        <label>(2)</label>
+        <mml:math id="m2"><mml:mrow></mml:mrow></mml:math>
+    </disp-formula>
+    </p>
+    <p>which does not need renormalization.</p>
+</disp-quote>

--- a/elifetools/tests/fixtures/test_body_block_content_render/content_32_expected.py
+++ b/elifetools/tests/fixtures/test_body_block_content_render/content_32_expected.py
@@ -1,0 +1,22 @@
+from collections import OrderedDict
+expected = [
+    OrderedDict([
+        ('type', 'excerpt'),
+        ('content', [
+            OrderedDict([
+                ('type', 'paragraph'),
+                ('text', '2) The competition term χ <sub>i</sub> requires renormalization, ... such as')
+            ]),
+            OrderedDict([
+                ('type', 'mathml'),
+                ('id', u'equ2'),
+                ('label', u'(2)'),
+                ('mathml', '<math><mrow/></math>')
+            ]),
+            OrderedDict([
+                ('type', 'paragraph'),
+                ('text', 'which does not need renormalization.')
+            ])
+        ])
+    ])
+]


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6136 in a recently prepared article, the `<disp-formula>` inside a `<disp-quote>` editor comment in an author response was omitted from JSON output.

In this PR test scenario is included resembling the article exhibiting the error, and the parser code is fixed to render the `<p>` tag inside a `<disp-quote>` tag properly.

Existing test cases are passing which is hopefully an indication there is minimal risk of negative consequences to rolling it out.

I tested manually converting XML to JSON for the particular article and the JSON output is valid according to the RAML schema.