### PR TITLE
Jenkins, disables build of downstream bot-lax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,4 @@ elifeLibrary {
     stage 'Project tests', {
         elifeLocalTests "./project_tests.sh"
     }
-
-    elifeMainlineOnly {
-        stage 'Downstream', {
-            build job: 'dependencies-bot-lax-adaptor-update-elife-tools', wait: false
-        }
-    }
 }


### PR DESCRIPTION
on a merge to `master`.
This update to bot-lax still happens but only when elife-tools is released, via Jenkinsfile.release