### PR TITLE
In utils.first(), use exceptions for non-iterable

### DIFF
--- a/elifetools/utils.py
+++ b/elifetools/utils.py
@@ -21,7 +21,7 @@ def first(value):
     if value is None:
         return None
     try:
-        return next(iter(value))
+        return next(value)
     except StopIteration:
         return None
     except TypeError:


### PR DESCRIPTION
I noticed this, which seems to work, otherwise the `TypeError` exception is not raised when the argument is a `list`.